### PR TITLE
Monitor failed rescue actions

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -11,6 +11,11 @@ class MonitoringController < ApplicationController
     status = ResqueMonitor.nagios_resque_email
     render text: status
   end
+  
+  def nagios_resque_failed
+    status = ResqueMonitor.nagios_resque_failed
+    render text: status
+  end
 
   private
 

--- a/app/modules/resque_monitor.rb
+++ b/app/modules/resque_monitor.rb
@@ -16,13 +16,23 @@ module ResqueMonitor
     check_queue options
   end
 
+  def self.nagios_resque_failed
+    options  = {
+      redis_host: 'localhost',
+      redis_port: '6379',
+      critical:   10,
+      warning:    5
+    }
+
+    check_failed options
+  end
+
   private
 
     def self.check_queue(options)
       queuename = "Resque queue #{options[:queue]}"
 
       redis = Redis.new(:host => options[:redis_host], :port => options[:redis_port])
-
       Resque.redis = redis
 
       begin
@@ -38,6 +48,28 @@ module ResqueMonitor
         status = "CRITICAL - #{queuename} size #{queue_size} #{NAGIOS_STATE_CRITICAL}"
       elsif queue_size >= options[:warning]
         status = "WARNING - #{queuename} size #{queue_size} #{NAGIOS_STATE_WARNING}"
+      end
+
+      status
+    end
+
+    def self.check_failed(options)
+      redis = Redis.new(:host => options[:redis_host], :port => options[:redis_port])
+      Resque.redis = redis
+
+      begin
+        failed_count = Resque::Failure.count
+      rescue
+        status = "CRITICAL - Cannot get Resque failed count #{NAGIOS_STATE_CRITICAL}"
+        return status
+      end
+
+      status = "OK - Resque failed count is ok #{NAGIOS_STATE_OK}"
+
+      if failed_count >= options[:critical]
+        status = "CRITICAL - Resque failed count is #{failed_count} #{NAGIOS_STATE_CRITICAL}"
+      elsif failed_count >= options[:warning]
+        status = "WARNING - Resque failed count is #{failed_count} #{NAGIOS_STATE_WARNING}"
       end
 
       status

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ require 'resque_web'
 
 Pupesoft::Application.routes.draw do
   get 'monitoring/nagios/resque/email', to: 'monitoring#nagios_resque_email'
+  get 'monitoring/nagios/resque/failed', to: 'monitoring#nagios_resque_failed'
 
   resources :currencies, except: :destroy
   root to: 'home#index'


### PR DESCRIPTION
Monitoring method for Nagios to alert if too many resque jobs are failing.
