### PR TITLE
Fix depreciation_difference

### DIFF
--- a/app/models/fixed_assets/commodity_row.rb
+++ b/app/models/fixed_assets/commodity_row.rb
@@ -11,7 +11,7 @@ class FixedAssets::CommodityRow < ActiveRecord::Base
 
   def depreciation_difference
     # Tämän EVL-poiston saman kuukauden SUMU-poisto
-    sumu = commodity.voucher.rows.where(tilino: commodity.fixed_assets_account).find_by_tapvm(transacted_at)
+    sumu = commodity.fixed_assets_rows.find_by_tapvm(transacted_at)
     sumu.summa - amount
   end
 

--- a/app/models/fixed_assets/commodity_row.rb
+++ b/app/models/fixed_assets/commodity_row.rb
@@ -11,7 +11,7 @@ class FixedAssets::CommodityRow < ActiveRecord::Base
 
   def depreciation_difference
     # Tämän EVL-poiston saman kuukauden SUMU-poisto
-    sumu = commodity.voucher.rows.find_by_tapvm(transacted_at)
+    sumu = commodity.voucher.rows.where(tilino: commodity.fixed_assets_account).find_by_tapvm(transacted_at)
     sumu.summa - amount
   end
 

--- a/test/models/fixed_assets/commodity_row_test.rb
+++ b/test/models/fixed_assets/commodity_row_test.rb
@@ -25,6 +25,10 @@ class FixedAssets::CommodityRowTest < ActiveSupport::TestCase
   end
 
   test 'has a depreciation difference' do
+    # Edit row manually to not break fixtures
+    head_voucher_row        = head_voucher_rows(:one)
+    head_voucher_row.tilino = '4444'
+    head_voucher_row.save
     assert_equal 233, @one.depreciation_difference
     assert_equal 1234, @two.depreciation_difference
   end


### PR DESCRIPTION
Fetching commodities vouchers rows was too loose. Deprication difference makes 2 rows in db. One with positive amount and one with negative. Sometimes the system returned wrong row. We need to filter with account to be sure to get the correct row.