### PR TITLE
Keyword translations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'resque-web', require: 'resque_web'
 
 gem 'date_validator'
 gem 'request_store'
+gem 'cocoon'
 
 group :assets do
   gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,7 @@ GEM
     arel (6.0.2)
     bcrypt (3.1.10)
     builder (3.2.2)
+    cocoon (1.2.6)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
     coffee-rails (4.1.0)
@@ -213,6 +214,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt
+  cocoon
   codeclimate-test-reporter
   dalli
   date_validator

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,4 @@
 //= require pickadate/picker.date
 //= require date_picker
 //= require toggle
+//= require cocoon

--- a/app/controllers/administration/terms_of_payments_controller.rb
+++ b/app/controllers/administration/terms_of_payments_controller.rb
@@ -53,22 +53,23 @@ class Administration::TermsOfPaymentsController < AdministrationController
 
     def terms_of_payment_params
       params.require(:terms_of_payment).permit(
-        :teksti,
-        :rel_pvm,
         :abs_pvm,
-        :kassa_relpvm,
-        :kassa_abspvm,
-        :kassa_alepros,
-        :jv,
-        :kateinen,
+        :erapvmkasin,
         :factoring,
-        :pankkiyhteystiedot,
         :itsetulostus,
         :jaksotettu,
-        :erapvmkasin,
-        :sallitut_maat,
+        :jarjestys,
+        :jv,
+        :kassa_abspvm,
+        :kassa_alepros,
+        :kassa_relpvm,
+        :kateinen,
         :kaytossa,
-        :jarjestys
+        :pankkiyhteystiedot,
+        :rel_pvm,
+        :sallitut_maat,
+        :teksti,
+        translations_attributes: [ :id, :kieli, :selitetark, :_destroy ]
       )
     end
 

--- a/app/helpers/keyword_helper.rb
+++ b/app/helpers/keyword_helper.rb
@@ -16,4 +16,16 @@ module KeywordHelper
 
     vat.uniq.sort
   end
+
+  def translatable_locales_options
+    [
+      [ 'Eesti',    'ee' ],
+      [ 'Englanti', 'en' ],
+      [ 'Norja',    'no' ],
+      [ 'Ruotsi',   'se' ],
+      [ 'Saksa',    'de' ],
+      [ 'Tanska',   'dk' ],
+      [ 'Venäjä',   'ru' ],
+    ]
+  end
 end

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -14,7 +14,8 @@ class Keyword < BaseModel
   def self.child_class_names
     {
       'ALV' => Keyword::Vat,
-      'ALVULK' => Keyword::ForeignVat
+      'ALVULK' => Keyword::ForeignVat,
+      'MAKSUEHTOKV' => Keyword::TermsOfPaymentTranslation
     }
   end
 end

--- a/app/models/keyword/terms_of_payment_translation.rb
+++ b/app/models/keyword/terms_of_payment_translation.rb
@@ -1,6 +1,8 @@
 class Keyword::TermsOfPaymentTranslation < Keyword
   belongs_to :terms_of_payment, foreign_key: :selite, primary_key: :tunnus
 
+  validates :kieli, :selitetark, presence: true
+
   # Rails requires sti_name method to return type column (laji) value
   def self.sti_name
     'MAKSUEHTOKV'

--- a/app/models/keyword/terms_of_payment_translation.rb
+++ b/app/models/keyword/terms_of_payment_translation.rb
@@ -1,0 +1,8 @@
+class Keyword::TermsOfPaymentTranslation < Keyword
+  belongs_to :terms_of_payment, foreign_key: :selite, primary_key: :tunnus
+
+  # Rails requires sti_name method to return type column (laji) value
+  def self.sti_name
+    'MAKSUEHTOKV'
+  end
+end

--- a/app/models/keyword/terms_of_payment_translation.rb
+++ b/app/models/keyword/terms_of_payment_translation.rb
@@ -1,7 +1,8 @@
 class Keyword::TermsOfPaymentTranslation < Keyword
   belongs_to :terms_of_payment, foreign_key: :selite, primary_key: :tunnus
 
-  validates :kieli, :selitetark, presence: true
+  validates :selitetark, presence: true
+  validates :kieli, inclusion: { in: %w{ee en no se de dk ru} }
 
   # Rails requires sti_name method to return type column (laji) value
   def self.sti_name

--- a/app/models/keyword/terms_of_payment_translation.rb
+++ b/app/models/keyword/terms_of_payment_translation.rb
@@ -3,6 +3,7 @@ class Keyword::TermsOfPaymentTranslation < Keyword
 
   validates :selitetark, presence: true
   validates :kieli, inclusion: { in: %w{ee en no se de dk ru} }
+  validates :kieli, uniqueness: { scope: [:yhtio, :selite] }
 
   # Rails requires sti_name method to return type column (laji) value
   def self.sti_name

--- a/app/models/terms_of_payment.rb
+++ b/app/models/terms_of_payment.rb
@@ -16,6 +16,7 @@ class TermsOfPayment < BaseModel
   validate :check_relations, if: :inactive?
 
   float_columns :kassa_alepros
+  accepts_nested_attributes_for :translations, allow_destroy: true
 
   before_save :defaults
 

--- a/app/models/terms_of_payment.rb
+++ b/app/models/terms_of_payment.rb
@@ -3,6 +3,7 @@ class TermsOfPayment < BaseModel
   include Searchable
 
   belongs_to :bank_detail, foreign_key: :pankkiyhteystiedot, primary_key: :tunnus
+  has_many :translations, foreign_key: :selite, primary_key: :tunnus, class_name: 'Keyword::TermsOfPaymentTranslation'
 
   validates :bank_detail, presence: true, unless: Proc.new { |t| t.pankkiyhteystiedot.nil? || t.pankkiyhteystiedot.zero? }
   validates :factoring, :sallitut_maat, allow_blank: true, length: { within: 1..50 }
@@ -42,6 +43,14 @@ class TermsOfPayment < BaseModel
 
   def bank_details_options
     company.bank_details.map { |i| [ i.nimitys, i.id ] }
+  end
+
+  def translated_locales
+    translations.map(&:kieli)
+  end
+
+  def name_translated(locale)
+    translations.find_by(kieli: locale).try(:selitetark) || teksti
   end
 
   private

--- a/app/views/administration/terms_of_payments/_form.html.erb
+++ b/app/views/administration/terms_of_payments/_form.html.erb
@@ -1,12 +1,21 @@
 <%= render "administration/form_errors", resource: @terms_of_payment %>
 
 <%= form_for @terms_of_payment do |f| %>
-
   <table>
     <tr>
-      <th><%= f.label :teksti %></th>
-      <td><%= f.text_field :teksti %></td>
+      <th>
+        <%= f.label :teksti %>
+      </th>
+
+      <td>
+        <%= f.text_field :teksti %>
+      </td>
+
+      <td rowspan='16' class='back' style='vertical-align: top; padding: 0px; padding-left: 30px;'>
+        <%= render "translations", f: f %>
+      </td>
     </tr>
+
     <tr>
       <th><%= f.label :rel_pvm %></th>
       <td><%= f.text_field :rel_pvm %></td>

--- a/app/views/administration/terms_of_payments/_translation_fields.html.erb
+++ b/app/views/administration/terms_of_payments/_translation_fields.html.erb
@@ -1,0 +1,13 @@
+<tr class='nested-fields'>
+  <td>
+    <%= f.select :kieli, translatable_locales_options, include_blank: true %>
+  </td>
+
+  <td>
+    <%= f.text_field :selitetark %>
+  </td>
+
+  <td>
+    <%= f.check_box :_destroy %>
+  </td>
+</tr>

--- a/app/views/administration/terms_of_payments/_translations.html.erb
+++ b/app/views/administration/terms_of_payments/_translations.html.erb
@@ -1,0 +1,18 @@
+<table id='translations'>
+
+  <tr>
+    <th><%= label_tag :kieli %></th>
+    <th><%= label_tag :teksti %></th>
+    <th><%= label_tag :poista %></th>
+  </tr>
+
+  <%= f.fields_for :translations do |translation| %>
+    <%= render 'translation_fields', f: translation %>
+  <% end %>
+
+</table>
+
+<br>
+
+<%= link_to_add_association 'Uusi käännös', f, :translations,
+    data: { association_insertion_method: :append, association_insertion_node: '#translations'} %>

--- a/app/views/administration/terms_of_payments/_translations.html.erb
+++ b/app/views/administration/terms_of_payments/_translations.html.erb
@@ -1,9 +1,9 @@
 <table id='translations'>
 
   <tr>
-    <th><%= label_tag :kieli %></th>
-    <th><%= label_tag :teksti %></th>
-    <th><%= label_tag :poista %></th>
+    <th><%= label_tag Keyword.human_attribute_name(:kieli) %></th>
+    <th><%= f.label :teksti %></th>
+    <th><%= label_tag t('helpers.submit.destroy', model: '') %></th>
   </tr>
 
   <%= f.fields_for :translations do |translation| %>
@@ -14,5 +14,5 @@
 
 <br>
 
-<%= link_to_add_association 'Uusi käännös', f, :translations,
+<%= link_to_add_association t('.link_new'), f, :translations,
     data: { association_insertion_method: :append, association_insertion_node: '#translations'} %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -37,3 +37,4 @@ ignore_unused:
 - 'administration.accounts.{manuaali_esto_options,tiliointi_tarkistus_options,toimijaliitos_options}.*'
 - 'administration.printers.{mediatyyppi_options,merkisto_options}.*'
 - 'administration.sum_levels.{kayttotarkoitus_options,kumulatiivinen_options}.*'
+- 'administration.qualifiers.{kaytossa_options}.*'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -139,6 +139,8 @@ de:
         viivastyskorko: 
         www: www
         ytunnus: Steuernummer
+      keyword:
+        kieli: Sprache
       packing_area:
         lokero: Fach
         nimi: Name
@@ -369,6 +371,8 @@ de:
         button_show_active: 
         button_show_removed: 
         header: 
+      translations:
+        link_new: Neue Übersetzung hinzufügen
       update:
         update_success: 
     update_access:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -139,6 +139,8 @@ et:
         viivastyskorko: Viivise protsent
         www: WWW
         ytunnus: KMKR Nr.
+      keyword:
+        kieli: Keel
       packing_area:
         nimi: Nimi
         printteri0: Komplekteerimisleht

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -139,6 +139,8 @@ fi:
         viivastyskorko: Viivästyskorkoprosentti
         www: WWW
         ytunnus: Y-tunnus
+      keyword:
+        kieli: Kieli
       packing_area:
         lokero: Lokero
         nimi: Nimi
@@ -186,6 +188,9 @@ fi:
         nimi: Nimi
         tunnus: Tunnus
         tyyppi: Tyyppi
+      translations:
+        kieli: Käännöksen kieli
+        selitetark: Käännetty teksti
     models:
       account: Tili
       carrier: Rahdinkuljettaja
@@ -402,6 +407,8 @@ fi:
         button_show_active: Näytä aktiiviset maksuehdot
         button_show_removed: Näytä poistetut maksuehdot
         header: Maksuedot
+      translations:
+        link_new: Lisää uusi käännös
       update:
         update_success: Maksuehto päivitettiin onnistuneesti
     update_access:
@@ -632,6 +639,7 @@ fi:
       prompt: Valitse
     submit:
       create: Luo %{model}
+      destroy: Poista %{model}
       submit: Tallenna %{model}
       update: Päivitä %{model}
   number:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -139,6 +139,8 @@ sv:
         viivastyskorko: 
         www: web
         ytunnus: Org.Nr
+      keyword:
+        kieli: Språk
       packing_area:
         nimi: Namn
         printteri0: Plocklista

--- a/test/controllers/administration/terms_of_payments_controller_test.rb
+++ b/test/controllers/administration/terms_of_payments_controller_test.rb
@@ -3,11 +3,13 @@ require 'test_helper'
 class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
 
   def setup
-    cookies[:pupesoft_session] = users(:joe).session
+    login users(:bob)
+    @joe = users(:joe)
     @top = terms_of_payments(:sixty_days_net)
   end
 
   test 'should get index' do
+    login @joe
     get :index
     assert_response :success
 
@@ -15,26 +17,21 @@ class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
   end
 
   test 'should get edit' do
-    cookies[:pupesoft_session] = users(:bob).session
     get :edit, id: @top.tunnus
     assert_response :success
   end
 
   test 'should get new' do
-    cookies[:pupesoft_session] = users(:bob).session
     get :new
     assert_response :success
   end
 
   test 'show should be edit' do
-    cookies[:pupesoft_session] = users(:bob).session
     get :show, id: @top.tunnus
     assert_response :success
   end
 
   test 'should create terms of payment' do
-    cookies[:pupesoft_session] = users(:bob).session
-
     assert_difference('TermsOfPayment.count', 1, response.body) do
 
       params = {
@@ -53,7 +50,6 @@ class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
   end
 
   test 'should not create terms of payment' do
-    cookies[:pupesoft_session] = users(:bob).session
     assert_no_difference('TermsOfPayment.count') do
 
       params = { not_existing_column: true }
@@ -64,8 +60,6 @@ class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
   end
 
   test 'should update terms of payment' do
-    cookies[:pupesoft_session] = users(:bob).session
-
     params = { teksti: "Kepakko" }
 
     patch :update, id: @top.id, terms_of_payment: params
@@ -73,8 +67,6 @@ class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
   end
 
   test 'should not update terms of payment' do
-    cookies[:pupesoft_session] = users(:bob).session
-
     params = { rel_pvm: 'a' }
 
     patch :update, id: @top.id, terms_of_payment: params
@@ -82,6 +74,7 @@ class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
   end
 
   test 'should show terms of payments not in use' do
+    login @joe
     params = { not_used: :yes }
 
     get :index, params
@@ -92,4 +85,50 @@ class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
     end
   end
 
+  test "should add translations" do
+    params = {
+      translations_attributes: {
+        "0" => {
+          kieli: 'se',
+          selitetark: '60 dagar netto',
+        }
+      }
+    }
+
+    assert_difference('Keyword::TermsOfPaymentTranslation.count') do
+      patch :update, id: @top.id, terms_of_payment: params
+    end
+  end
+
+  test "should update and destroy translations" do
+    translated = keywords(:top_locale_se)
+
+    params = {
+      translations_attributes: {
+        "0" => {
+          id: translated.id,
+          selitetark: 'a translation',
+        }
+      }
+    }
+
+    assert_no_difference('Keyword::TermsOfPaymentTranslation.count') do
+      patch :update, id: translated.terms_of_payment.id, terms_of_payment: params
+    end
+
+    assert_equal 'a translation', translated.reload.selitetark
+
+    params = {
+      translations_attributes: {
+        "0" => {
+          id: translated.id,
+          _destroy: 'true',
+        }
+      }
+    }
+
+    assert_difference('Keyword::TermsOfPaymentTranslation.count', -1) do
+      patch :update, id: translated.terms_of_payment.id, terms_of_payment: params
+    end
+  end
 end

--- a/test/controllers/administration/terms_of_payments_controller_test.rb
+++ b/test/controllers/administration/terms_of_payments_controller_test.rb
@@ -89,7 +89,7 @@ class Administration::TermsOfPaymentsControllerTest < ActionController::TestCase
     params = {
       translations_attributes: {
         "0" => {
-          kieli: 'se',
+          kieli: 'no',
           selitetark: '60 dagar netto',
         }
       }

--- a/test/fixtures/keywords.yml
+++ b/test/fixtures/keywords.yml
@@ -16,3 +16,25 @@ foreign_vat:
   laatija: joe
   luontiaika: <%= Time.now %>
   muutospvm: <%= Time.now %>
+
+top_locale_se:
+  yhtio: acme
+  selite: <%= ActiveRecord::FixtureSet.identify(:sixty_days_net) %>
+  selitetark: 60 dagar netto
+  kieli: se
+  laji: MAKSUEHTOKV
+  muuttaja: joe
+  laatija: joe
+  luontiaika: <%= Time.now %>
+  muutospvm: <%= Time.now %>
+
+top_locale_en:
+  yhtio: acme
+  selite: <%= ActiveRecord::FixtureSet.identify(:sixty_days_net) %>
+  selitetark: 60 days net
+  kieli: en
+  laji: MAKSUEHTOKV
+  muuttaja: joe
+  laatija: joe
+  luontiaika: <%= Time.now %>
+  muutospvm: <%= Time.now %>

--- a/test/models/keyword_test.rb
+++ b/test/models/keyword_test.rb
@@ -4,15 +4,17 @@ class KeywordTest < ActiveSupport::TestCase
   setup do
     @vat = keywords(:vat)
     @foreign_vat = keywords(:foreign_vat)
+    @top_translation = keywords(:top_locale_se)
   end
 
   test "fixtures are valid" do
     assert @vat.valid?, @vat.errors.full_messages
     assert @foreign_vat.valid?, @foreign_vat.errors.full_messages
+    assert @top_translation.valid?, @top_translation.errors.full_messages
+    assert keywords(:top_locale_en).valid?
   end
 
   test 'top translation relation' do
-    top_translation = keywords(:top_locale_se)
-    assert TermsOfPayment, top_translation.terms_of_payment.class
+    assert TermsOfPayment, @top_translation.terms_of_payment.class
   end
 end

--- a/test/models/keyword_test.rb
+++ b/test/models/keyword_test.rb
@@ -17,4 +17,27 @@ class KeywordTest < ActiveSupport::TestCase
   test 'top translation relation' do
     assert TermsOfPayment, @top_translation.terms_of_payment.class
   end
+
+  test 'top translation scope' do
+    # translations :kieli is scoped [:yhtio, :selite]
+    new_translation = @top_translation.dup
+    refute new_translation.valid?
+
+    error_message = [:kieli, I18n.t('errors.messages.taken')]
+    assert_equal error_message, new_translation.errors.first
+
+    # changing yhtio should make it valid
+    new_translation.yhtio = 'esto'
+    assert new_translation.valid?
+
+    # changing selite should make it valid
+    new_translation = @top_translation.dup
+    new_translation.selite = 324
+    assert new_translation.valid?
+
+    # or changing kieli should make it valid
+    new_translation = @top_translation.dup
+    new_translation.kieli = 'no'
+    assert new_translation.valid?
+  end
 end

--- a/test/models/keyword_test.rb
+++ b/test/models/keyword_test.rb
@@ -10,4 +10,9 @@ class KeywordTest < ActiveSupport::TestCase
     assert @vat.valid?, @vat.errors.full_messages
     assert @foreign_vat.valid?, @foreign_vat.errors.full_messages
   end
+
+  test 'top translation relation' do
+    top_translation = keywords(:top_locale_se)
+    assert TermsOfPayment, top_translation.terms_of_payment.class
+  end
 end

--- a/test/models/terms_of_payment_test.rb
+++ b/test/models/terms_of_payment_test.rb
@@ -129,4 +129,11 @@ class TermsOfPaymentTest < ActiveSupport::TestCase
 
     # no need to test enums more here, since we have tested them in "kateinen" enums test
   end
+
+  test 'translations' do
+    assert_equal 2, @top.translations.count
+    assert_equal ["en", "se"], @top.translated_locales
+    assert_equal "60 days net", @top.name_translated(:en)
+    assert_equal @top.teksti, @top.name_translated('not_valid_locale')
+  end
 end


### PR DESCRIPTION
Example translation flow for Terms of Payment using old Pupesoft Keyword -functionality.

* Added STI model for TOP keyword translations
* Added relations between TOP and its translations
* TOP model and controller now accepts nested attributes
* Added cocoon gem for easier record adding with JS
* Added translations to TOP view