### PR TITLE
Myyntilaskun valuuttakurssi

### DIFF
--- a/db/migrate/20151028120841_sales_invoice_currency_rate_selector.rb
+++ b/db/migrate/20151028120841_sales_invoice_currency_rate_selector.rb
@@ -1,0 +1,9 @@
+class SalesInvoiceCurrencyRateSelector < ActiveRecord::Migration
+  def up
+    add_column :yhtion_parametrit, :myyntilaskujen_kurssipaiva, :tinyint, limit: 1, default: 0, null: false, after: :ostolaskujen_kurssipaiva
+  end
+
+  def down
+    remove_column :yhtion_parametrit, :myyntilaskujen_kurssipaiva
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151019065817) do
+ActiveRecord::Schema.define(version: 20151028120841) do
 
   create_table "abc_aputaulu", primary_key: "tunnus", force: :cascade do |t|
     t.string   "yhtio",              limit: 5,                            default: "",  null: false
@@ -3454,6 +3454,7 @@ ActiveRecord::Schema.define(version: 20151019065817) do
     t.string   "ostolaskujen_paivays",                             limit: 1,                              default: "",    null: false
     t.string   "ostolaskujen_oletusvaluutta",                      limit: 1,                              default: "",    null: false
     t.integer  "ostolaskujen_kurssipaiva",                         limit: 4,                              default: 0,     null: false
+    t.integer  "myyntilaskujen_kurssipaiva",                       limit: 1,                              default: 0,     null: false
     t.string   "ostolaskun_kulutilit",                             limit: 1,                              default: "",    null: false
     t.string   "ostolaskun_kulutilit_kayttaytyminen",              limit: 1,                              default: "",    null: false
     t.string   "tarkenteiden_tarkistus_hyvaksynnassa",             limit: 1,                              default: "",    null: false


### PR DESCRIPTION
Uusi yhtiön parametri jolla voi säätää minkä päivän valuuttakurssi myyntitilaukselle/laskulle valitaan.

Parametrillä on seuraavat asennot:
-Myyntilaskun valuuttakurssi tilauksen luontipäivän mukaan
-Myyntilaskun valuuttakurssi tilauksen toimituspäivän mukaan
-Myyntilaskun valuuttakurssi laskun päiväyksen mukaan
-Myyntilaskun valuuttakurssi laskutushetken mukaan