### PR TITLE
Bank account fix

### DIFF
--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -79,6 +79,8 @@ class BankAccount < BaseModel
     end
 
     def check_bic
+      return if iban =~ /\A[a-zA-Z öäåÖÄÅ]+\z/
+
       if finnish_company? && !valid_bic?(bic)
         errors.add :bic, I18n.t('errors.messages.invalid')
       end

--- a/test/controllers/administration/bank_accounts_controller_test.rb
+++ b/test/controllers/administration/bank_accounts_controller_test.rb
@@ -89,7 +89,7 @@ class Administration::BankAccountsControllerTest < ActionController::TestCase
   test "does not update with invalid parameters" do
     login users(:bob)
 
-    params = { bic: "kala", iban: "kissa" }
+    params = { bic: "kala", iban: "kissa1" }
 
     patch :update, id: @ba.tunnus, bank_account: params
     assert_template :edit


### PR DESCRIPTION
- Allow empty BIC if IBAN contains only letters