### PR TITLE
Customer price list fix

### DIFF
--- a/app/controllers/reports/customer_price_lists_controller.rb
+++ b/app/controllers/reports/customer_price_lists_controller.rb
@@ -20,6 +20,7 @@ class Reports::CustomerPriceListsController < ApplicationController
     end
 
     render pdf:         t('.filename'),
+           disposition: :attachment,
            footer:      { html: { template: 'reports/customer_price_lists/footer.html.erb' } },
            header:      { right: "#{t('.page')} [page] / [toPage]" },
            template:    'reports/customer_price_lists/report.html.erb'

--- a/app/views/reports/customer_price_lists/index.html.erb
+++ b/app/views/reports/customer_price_lists/index.html.erb
@@ -61,6 +61,6 @@
 
   <br>
 
-  <%= submit_tag t('.generate'), data: { disable_with: t('.loading') } %>
+  <%= submit_tag t('.generate') %>
 
 <% end %>

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -996,7 +996,6 @@ fi:
         date_end: Loppupvm
         date_start: Alkupvm
         generate: Generoi
-        loading: Ladataan...
         product_filter: Tuoterajaus
         product_image: Tuotekuva
         target_type: Kohdetyyppi


### PR DESCRIPTION
- Render customer price list as an attachment, because at least Chrome thinks the generated pdf is an HTML document when trying to save it.
- Don't disable the the submit button so that the form can be used to generate subsequent price lists