### PR TITLE
Huutokauppa methods

### DIFF
--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -147,6 +147,10 @@ class HuutokauppaMail
     )
   end
 
+  def find_order
+    SalesOrder::Draft.find_by!(viesti: auction_id)
+  end
+
   private
 
     def customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -131,6 +131,22 @@ class HuutokauppaMail
     auction_info[:vat_amount].sub(',', '.').to_d
   end
 
+  def create_or_find_customer
+    Customer.create_with(
+      gsm: customer_phone,
+      kauppatapahtuman_luonne: Keyword::NatureOfTransaction.first.selite,
+      luontiaika: Time.now,
+      muutospvm: Time.now,
+      nimi: customer_name,
+      osoite: customer_address,
+      postino: customer_postcode,
+      postitp: customer_city,
+      ytunnus: auction_id
+    ).find_or_create_by(
+      email: customer_email
+    )
+  end
+
   private
 
     def customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -132,7 +132,7 @@ class HuutokauppaMail
   end
 
   def find_customer
-    Customer.find_by!(email: customer_email) if customer_email
+    @customer ||= Customer.find_by!(email: customer_email) if customer_email
   end
 
   def create_customer
@@ -149,6 +149,19 @@ class HuutokauppaMail
       postino: customer_postcode,
       postitp: customer_city,
       ytunnus: auction_id,
+    )
+  end
+
+  def update_customer
+    return unless find_customer
+
+    find_customer.update!(
+      gsm: customer_phone,
+      muutospvm: Time.now,
+      nimi: customer_name,
+      osoite: customer_address,
+      postino: customer_postcode,
+      postitp: customer_city,
     )
   end
 

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -132,7 +132,24 @@ class HuutokauppaMail
   end
 
   def find_customer
-    Customer.find_by!(email: customer_email) if customer_email.present?
+    Customer.find_by!(email: customer_email) if customer_email
+  end
+
+  def create_customer
+    return unless customer_name
+
+    Customer.create!(
+      email: customer_email,
+      gsm: customer_phone,
+      kauppatapahtuman_luonne: Keyword::NatureOfTransaction.first.selite,
+      luontiaika: Time.now,
+      muutospvm: Time.now,
+      nimi: customer_name,
+      osoite: customer_address,
+      postino: customer_postcode,
+      postitp: customer_city,
+      ytunnus: auction_id,
+    )
   end
 
   def find_order

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -2,6 +2,9 @@ class HuutokauppaMail
   attr_reader :mail
 
   def initialize(raw_source)
+    raise 'Current company must be set' unless Current.company
+    raise 'Current user must be set'    unless Current.user
+
     @mail = Mail.new(raw_source)
     @doc  = Nokogiri::HTML(@mail.body.to_s.force_encoding(Encoding::UTF_8))
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -223,6 +223,20 @@ class HuutokauppaMail
     SalesOrder::Draft.find(sales_order_id)
   end
 
+  def add_delivery_row_to_order(order)
+    return unless delivery_price_without_vat
+
+    order.rows.create!(
+      alv: delivery_vat_percent,
+      hinta: delivery_price_without_vat,
+      hinta_alkuperainen: delivery_price_without_vat,
+      hinta_valuutassa: delivery_price_without_vat,
+      product: Parameter.freight_product,
+      rivihinta: delivery_price_without_vat,
+      rivihinta_valuutassa: delivery_price_without_vat,
+    )
+  end
+
   private
 
     def customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -79,6 +79,12 @@ class HuutokauppaMail
     delivery_info[:email]
   end
 
+  def delivery_price_without_vat
+    return unless delivery_price_with_vat
+
+    delivery_price_with_vat - delivery_vat_amount
+  end
+
   def delivery_price_with_vat
     return unless auction_info[:delivery_price_with_vat]
 

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -195,6 +195,18 @@ class HuutokauppaMail
     )
   end
 
+  def update_order_product_info
+    find_order.rows.first.update!(
+      alv: auction_vat_percent,
+      hinta: auction_price_without_vat,
+      hinta_alkuperainen: auction_price_without_vat,
+      hinta_valuutassa: auction_price_without_vat,
+      nimitys: auction_title,
+      rivihinta: auction_price_without_vat,
+      rivihinta_valuutassa: auction_price_without_vat,
+    )
+  end
+
   private
 
     def customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -131,22 +131,6 @@ class HuutokauppaMail
     auction_info[:vat_amount].sub(',', '.').to_d
   end
 
-  def create_or_find_customer
-    Customer.create_with(
-      gsm: customer_phone,
-      kauppatapahtuman_luonne: Keyword::NatureOfTransaction.first.selite,
-      luontiaika: Time.now,
-      muutospvm: Time.now,
-      nimi: customer_name,
-      osoite: customer_address,
-      postino: customer_postcode,
-      postitp: customer_city,
-      ytunnus: auction_id
-    ).find_or_create_by(
-      email: customer_email
-    )
-  end
-
   def find_customer
     Customer.find_by!(email: customer_email) if customer_email.present?
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -147,6 +147,10 @@ class HuutokauppaMail
     )
   end
 
+  def find_customer
+    Customer.find_by!(email: customer_email) if customer_email.present?
+  end
+
   def find_order
     SalesOrder::Draft.find_by!(viesti: auction_id)
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -182,6 +182,19 @@ class HuutokauppaMail
     )
   end
 
+  def update_order_delivery_info
+    return unless delivery_name
+
+    find_order.update!(
+      toim_email: delivery_email,
+      toim_nimi: delivery_name,
+      toim_osoite: delivery_address,
+      toim_postino: delivery_postcode,
+      toim_postitp: delivery_city,
+      toim_puh: delivery_phone,
+    )
+  end
+
   private
 
     def customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -207,6 +207,16 @@ class HuutokauppaMail
     )
   end
 
+  def create_sales_order
+    return unless customer_name
+
+    response = LegacyMethods.pupesoft_function(:luo_myyntitilausotsikko,
+                                               customer_id: find_customer.id)
+    sales_order_id = response[:sales_order_id]
+
+    SalesOrder::Draft.find(sales_order_id)
+  end
+
   private
 
     def customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -166,7 +166,20 @@ class HuutokauppaMail
   end
 
   def find_order
-    SalesOrder::Draft.find_by!(viesti: auction_id)
+    @order ||= SalesOrder::Draft.find_by!(viesti: auction_id)
+  end
+
+  def update_order_customer_info
+    return unless customer_name
+
+    find_order.update!(
+      email: customer_email,
+      nimi: customer_name,
+      osoite: customer_address,
+      postino: customer_postcode,
+      postitp: customer_city,
+      puh: customer_phone,
+    )
   end
 
   private

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -151,8 +151,6 @@ class HuutokauppaMail
       email: customer_email,
       gsm: customer_phone,
       kauppatapahtuman_luonne: Keyword::NatureOfTransaction.first.selite,
-      luontiaika: Time.now,
-      muutospvm: Time.now,
       nimi: customer_name,
       osoite: customer_address,
       postino: customer_postcode,
@@ -166,7 +164,6 @@ class HuutokauppaMail
 
     find_customer.update!(
       gsm: customer_phone,
-      muutospvm: Time.now,
       nimi: customer_name,
       osoite: customer_address,
       postino: customer_postcode,
@@ -219,8 +216,7 @@ class HuutokauppaMail
   def create_sales_order
     return unless customer_name
 
-    response = LegacyMethods.pupesoft_function(:luo_myyntitilausotsikko,
-                                               customer_id: find_customer.id)
+    response = LegacyMethods.pupesoft_function(:luo_myyntitilausotsikko, customer_id: find_customer.id)
     sales_order_id = response[:sales_order_id]
 
     SalesOrder::Draft.find(sales_order_id)

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -231,7 +231,7 @@ class HuutokauppaMail
       hinta: delivery_price_without_vat,
       hinta_alkuperainen: delivery_price_without_vat,
       hinta_valuutassa: delivery_price_without_vat,
-      product: Parameter.freight_product,
+      product: order.company.parameter.freight_product,
       rivihinta: delivery_price_without_vat,
       rivihinta_valuutassa: delivery_price_without_vat,
     )

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -15,16 +15,11 @@ class Customer < BaseModel
   validates :asiakasnro, uniqueness: { scope: :yhtio }, allow_blank: true
   validates :maa, inclusion: { in: proc { Country.pluck(:koodi) } }
   validates :nimi, presence: true
-  validates :osasto,
-            inclusion: { in: ->(_c) { Keyword::CustomerCategory.pluck(:selite) } },
-            allow_blank: true
-  validates :ryhma,
-            inclusion: { in: ->(_c) { Keyword::CustomerSubcategory.pluck(:selite) } },
-            allow_blank: true
+  validates :osasto, inclusion: { in: ->(_c) { Keyword::CustomerCategory.pluck(:selite) } }, allow_blank: true
+  validates :ryhma, inclusion: { in: ->(_c) { Keyword::CustomerSubcategory.pluck(:selite) } }, allow_blank: true
   validates :ytunnus, presence: true, uniqueness: { scope: :yhtio }
   validates :alv, inclusion: { in: ->(_c) { Keyword::Vat.pluck(:selite).map(&:to_i) } }
-  validates :kauppatapahtuman_luonne,
-            inclusion: { in: ->(_c) { Keyword::NatureOfTransaction.pluck(:selite).map(&:to_i) } }
+  validates :kauppatapahtuman_luonne, inclusion: { in: ->(_c) { Keyword::NatureOfTransaction.pluck(:selite).map(&:to_i) } }
 
   validate :validate_chn
   validate :validate_delivery_method

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -15,11 +15,16 @@ class Customer < BaseModel
   validates :asiakasnro, uniqueness: { scope: :yhtio }, allow_blank: true
   validates :maa, inclusion: { in: proc { Country.pluck(:koodi) } }
   validates :nimi, presence: true
-  validates :osasto, inclusion: { in: ->(c) { c.company.keywords.where(laji: :asiakasosasto).pluck(:selite) } }
-  validates :ryhma, inclusion: { in: ->(c) { c.company.keywords.where(laji: :asiakasryhma).pluck(:selite) } }
+  validates :osasto,
+            inclusion: { in: ->(_c) { Keyword::CustomerCategory.pluck(:selite) } },
+            allow_blank: true
+  validates :ryhma,
+            inclusion: { in: ->(_c) { Keyword::CustomerSubcategory.pluck(:selite) } },
+            allow_blank: true
   validates :ytunnus, presence: true, uniqueness: { scope: :yhtio }
   validates :alv, inclusion: { in: ->(_c) { Keyword::Vat.pluck(:selite).map(&:to_i) } }
-  validates :kauppatapahtuman_luonne, inclusion: { in: ->(_c) { Keyword::NatureOfTransaction.pluck(:selite).map(&:to_i) } }
+  validates :kauppatapahtuman_luonne,
+            inclusion: { in: ->(_c) { Keyword::NatureOfTransaction.pluck(:selite).map(&:to_i) } }
 
   validate :validate_chn
   validate :validate_delivery_method

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -2,13 +2,11 @@ class Parameter < BaseModel
   self.table_name = :yhtion_parametrit
   self.primary_key = :tunnus
 
+  belongs_to :freight_product, class_name: 'Product', foreign_key: :rahti_tuotenumero, primary_key: :tuoteno
+
   enum saldo_kasittely: {
     default_stock_management: '',
     stock_management_by_pick_date: 'T',
     stock_management_by_pick_date_and_with_future_reservations: 'U',
   }
-
-  def self.freight_product
-    Product.find_by!(tuoteno: first.rahti_tuotenumero)
-  end
 end

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -7,4 +7,8 @@ class Parameter < BaseModel
     stock_management_by_pick_date: 'T',
     stock_management_by_pick_date_and_with_future_reservations: 'U',
   }
+
+  def self.freight_product
+    Product.find_by!(tuoteno: first.rahti_tuotenumero)
+  end
 end

--- a/app/models/sales_order/draft.rb
+++ b/app/models/sales_order/draft.rb
@@ -5,4 +5,8 @@ class SalesOrder::Draft < SalesOrder::Base
   def self.sti_name
     "N"
   end
+
+  def mark_as_done
+    LegacyMethods.pupesoft_function(:tilaus_valmis, order_id: id)
+  end
 end

--- a/app/modules/legacy_methods.rb
+++ b/app/modules/legacy_methods.rb
@@ -25,6 +25,19 @@ module LegacyMethods
     price
   end
 
+  def self.pupesoft_function(function, params)
+    Open3.popen2('php',
+                 '-f',
+                 'pupenext.php',
+                 Current.company.yhtio,
+                 Current.user.kuka,
+                 function.to_s,
+                 params.to_json,
+                 chdir: LEGACY_API_DIR) do |_stdin, stdout, _stderr|
+      JSON.parse(stdout.gets, symbolize_names: true)
+    end
+  end
+
   private
 
     def self.discount_price(target, target_id, product_id)

--- a/app/modules/legacy_methods.rb
+++ b/app/modules/legacy_methods.rb
@@ -36,6 +36,8 @@ module LegacyMethods
                  chdir: LEGACY_API_DIR) do |_stdin, stdout, _stderr|
       JSON.parse(stdout.gets, symbolize_names: true)
     end
+  rescue JSON::ParserError => e
+    { error: "There was an error parsing the JSON response from Pupesoft. Message: #{e.message}" }
   end
 
   private

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -7,6 +7,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     keyword/customer_subcategories
     keywords
     sales_order/drafts
+    sales_order/rows
   )
 
   setup do
@@ -407,6 +408,29 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
     @emails_without_delivery_info.each do |email|
       refute email.update_order_delivery_info
+    end
+  end
+
+  test '#update_order_product_info' do
+    [
+      @auction_ended,
+      @bidder_picks_up,
+      @delivery_offer_request,
+      @delivery_ordered,
+      @offer_accepted,
+      @offer_automatically_accepted,
+      @offer_declined,
+      @purchase_price_paid,
+    ].each do |email|
+      assert email.update_order_product_info
+
+      assert_equal email.auction_price_without_vat, email.find_order.rows.first.hinta
+      assert_equal email.auction_price_without_vat, email.find_order.rows.first.hinta_alkuperainen
+      assert_equal email.auction_price_without_vat, email.find_order.rows.first.hinta_valuutassa
+      assert_equal email.auction_price_without_vat, email.find_order.rows.first.rivihinta
+      assert_equal email.auction_price_without_vat, email.find_order.rows.first.rivihinta_valuutassa
+      assert_equal email.auction_title,             email.find_order.rows.first.nimitys
+      assert_equal email.auction_vat_percent,       email.find_order.rows.first.alv
     end
   end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -375,4 +375,21 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_order
     assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_order
   end
+
+  test 'update_order_customer_info' do
+    [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
+      assert email.update_order_customer_info
+
+      assert_equal email.customer_address,  email.find_order.osoite
+      assert_equal email.customer_city,     email.find_order.postitp
+      assert_equal email.customer_email,    email.find_order.email
+      assert_equal email.customer_name,     email.find_order.nimi
+      assert_equal email.customer_phone,    email.find_order.puh
+      assert_equal email.customer_postcode, email.find_order.postino
+    end
+
+    @emails_without_customer_info.each do |email|
+      refute email.update_order_customer_info
+    end
+  end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 
 class HuutokauppaMailTest < ActiveSupport::TestCase
   fixtures %w(
+    countries
     customers
     keyword/customer_categories
     keyword/customer_subcategories

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -329,31 +329,25 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#create_or_find_customer' do
-    @mails.values_at(:offer_accepted,
-                     :offer_automatically_accepted,
-                     :purchase_price_paid).each do |mails|
-      mails.each do |mail|
-        assert_difference 'Customer.count' do
-          mail.create_or_find_customer
-        end
-
-        customer = Customer.last
-
-        assert_equal mail.customer_name,     customer.nimi
-        assert_equal mail.customer_email,    customer.email
-        assert_equal mail.customer_phone,    customer.gsm
-        assert_equal mail.customer_address,  customer.osoite
-        assert_equal mail.customer_postcode, customer.postino
-        assert_equal mail.customer_city,     customer.postitp
-
-        Customer.last.destroy!
+    [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |mail|
+      assert_difference 'Customer.count' do
+        mail.create_or_find_customer
       end
+
+      customer = Customer.last
+
+      assert_equal mail.customer_name,     customer.nimi
+      assert_equal mail.customer_email,    customer.email
+      assert_equal mail.customer_phone,    customer.gsm
+      assert_equal mail.customer_address,  customer.osoite
+      assert_equal mail.customer_postcode, customer.postino
+      assert_equal mail.customer_city,     customer.postitp
+
+      Customer.last.destroy!
     end
 
     assert_no_difference 'Customer.count' do
-      @mails.values_at(@emails_without_customer_info).each do |mails|
-        mails.each(&:create_or_find_customer)
-      end
+      @emails_without_customer_info.each(&:create_or_find_customer)
     end
   end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -329,29 +329,6 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 72.0,  @purchase_price_paid.auction_vat_amount
   end
 
-  test '#create_or_find_customer' do
-    [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |mail|
-      assert_difference 'Customer.count' do
-        mail.create_or_find_customer
-      end
-
-      customer = Customer.last
-
-      assert_equal mail.customer_name,     customer.nimi
-      assert_equal mail.customer_email,    customer.email
-      assert_equal mail.customer_phone,    customer.gsm
-      assert_equal mail.customer_address,  customer.osoite
-      assert_equal mail.customer_postcode, customer.postino
-      assert_equal mail.customer_city,     customer.postitp
-
-      Customer.last.destroy!
-    end
-
-    assert_no_difference 'Customer.count' do
-      @emails_without_customer_info.each(&:create_or_find_customer)
-    end
-  end
-
   test '#find_customer' do
     assert_equal customers(:huutokauppa_customer_1), @offer_accepted.find_customer
     assert_equal customers(:huutokauppa_customer_2), @offer_automatically_accepted.find_customer

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -6,6 +6,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     keyword/customer_categories
     keyword/customer_subcategories
     keywords
+    sales_order/drafts
   )
 
   setup do
@@ -349,5 +350,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_no_difference 'Customer.count' do
       @emails_without_customer_info.each(&:create_or_find_customer)
     end
+  end
+
+  test '#find_order' do
+    assert_equal sales_order_drafts(:huutokauppa_279590), @auction_ended.find_order
+    assert_equal sales_order_drafts(:huutokauppa_285888), @bidder_picks_up.find_order
+    assert_equal sales_order_drafts(:huutokauppa_270265), @delivery_offer_request.find_order
+    assert_equal sales_order_drafts(:huutokauppa_274472), @delivery_ordered.find_order
+    assert_equal sales_order_drafts(:huutokauppa_277075), @offer_accepted.find_order
+    assert_equal sales_order_drafts(:huutokauppa_270265), @offer_automatically_accepted.find_order
+    assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_order
+    assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_order
   end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -45,6 +45,17 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     ]
   end
 
+  test 'exception is thrown if company and user are not set' do
+    file = huutokauppa_email(:offer_automatically_accepted_1)
+
+    Current.company = nil
+    assert_raise { HuutokauppaMail.new(file) }
+
+    Current.company = companies(:acme)
+    Current.user    = nil
+    assert_raise { HuutokauppaMail.new(file) }
+  end
+
   test 'initializes correctly with a raw email source' do
     huutokauppa_mail = nil
     file = huutokauppa_email(:offer_automatically_accepted_1)

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -26,7 +26,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @bidder_picks_up,
       @delivery_offer_request,
       @delivery_ordered,
-      @offer_declined
+      @offer_declined,
     ]
 
     @emails_without_delivery_info = [
@@ -35,7 +35,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_accepted,
       @offer_automatically_accepted,
       @offer_declined,
-      @purchase_price_paid
+      @purchase_price_paid,
     ]
   end
 
@@ -376,7 +376,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_order
   end
 
-  test 'update_order_customer_info' do
+  test '#update_order_customer_info' do
     [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
       assert email.update_order_customer_info
 
@@ -390,6 +390,23 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
     @emails_without_customer_info.each do |email|
       refute email.update_order_customer_info
+    end
+  end
+
+  test '#update_order_delivery_info' do
+    [@delivery_offer_request, @delivery_ordered].each do |email|
+      assert email.update_order_delivery_info
+
+      assert_equal email.delivery_address,  email.find_order.toim_osoite
+      assert_equal email.delivery_city,     email.find_order.toim_postitp
+      assert_equal email.delivery_email,    email.find_order.toim_email
+      assert_equal email.delivery_name,     email.find_order.toim_nimi
+      assert_equal email.delivery_phone,    email.find_order.toim_puh
+      assert_equal email.delivery_postcode, email.find_order.toim_postino
+    end
+
+    @emails_without_delivery_info.each do |email|
+      refute email.update_order_delivery_info
     end
   end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -352,6 +352,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#find_customer' do
+    assert_equal customers(:huutokauppa_customer_1), @offer_accepted.find_customer
+    assert_equal customers(:huutokauppa_customer_2), @offer_automatically_accepted.find_customer
+    assert_equal customers(:huutokauppa_customer_2), @purchase_price_paid.find_customer
+
+    @emails_without_customer_info.each do |email|
+      assert_nil email.find_customer
+    end
+  end
+
   test '#find_order' do
     assert_equal sales_order_drafts(:huutokauppa_279590), @auction_ended.find_order
     assert_equal sales_order_drafts(:huutokauppa_285888), @bidder_picks_up.find_order

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -339,6 +339,22 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#create_customer' do
+    [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
+      Customer.delete_all
+
+      assert_difference 'Customer.count' do
+        email.create_customer
+      end
+    end
+
+    @emails_without_customer_info.each do |email|
+      assert_no_difference 'Customer.count' do
+        email.create_customer
+      end
+    end
+  end
+
   test '#find_order' do
     assert_equal sales_order_drafts(:huutokauppa_279590), @auction_ended.find_order
     assert_equal sales_order_drafts(:huutokauppa_285888), @bidder_picks_up.find_order

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -194,6 +194,18 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#delivery_price_without_vat' do
+    assert_equal 0,     @bidder_picks_up.delivery_price_without_vat
+    assert_equal 14.47, @delivery_ordered.delivery_price_without_vat
+
+    assert_nil @auction_ended.delivery_price_without_vat
+    assert_nil @delivery_offer_request.delivery_price_without_vat
+    assert_nil @offer_accepted.delivery_price_without_vat
+    assert_nil @offer_automatically_accepted.delivery_price_without_vat
+    assert_nil @offer_declined.delivery_price_without_vat
+    assert_nil @purchase_price_paid.delivery_price_without_vat
+  end
+
   test '#delivery_price_with_vat' do
     assert_equal 0.0,   @bidder_picks_up.delivery_price_with_vat
     assert_equal 17.95, @delivery_ordered.delivery_price_with_vat

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -355,6 +355,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#update_customer' do
+    [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
+      assert email.update_customer
+    end
+
+    @emails_without_customer_info.each do |email|
+      refute email.update_customer
+    end
+  end
+
   test '#find_order' do
     assert_equal sales_order_drafts(:huutokauppa_279590), @auction_ended.find_order
     assert_equal sales_order_drafts(:huutokauppa_285888), @bidder_picks_up.find_order

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -7,6 +7,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     keyword/customer_categories
     keyword/customer_subcategories
     keywords
+    products
     sales_order/drafts
     sales_order/rows
   )
@@ -468,6 +469,37 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         assert_no_difference 'SalesOrder::Draft.count' do
           email.create_sales_order
         end
+      end
+    end
+  end
+
+  test '#add_delivery_row_to_order' do
+    order = SalesOrder::Draft.new
+    order.save(validate: false)
+
+    [@bidder_picks_up, @delivery_ordered].each do |email|
+      assert_difference 'SalesOrder::Row.count' do
+        delivery_row = email.add_delivery_row_to_order(order)
+
+        assert_equal email.delivery_price_without_vat, delivery_row.hinta
+        assert_equal email.delivery_price_without_vat, delivery_row.hinta_alkuperainen
+        assert_equal email.delivery_price_without_vat, delivery_row.hinta_valuutassa
+        assert_equal email.delivery_price_without_vat, delivery_row.rivihinta
+        assert_equal email.delivery_price_without_vat, delivery_row.rivihinta_valuutassa
+        assert_equal email.delivery_vat_percent,       delivery_row.alv
+      end
+    end
+
+    [
+      @auction_ended,
+      @delivery_offer_request,
+      @offer_accepted,
+      @offer_automatically_accepted,
+      @offer_declined,
+      @purchase_price_paid,
+    ].each do |email|
+      assert_no_difference 'Row.count' do
+        email.add_delivery_row_to_order(order)
       end
     end
   end

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -43,3 +43,11 @@ lissu:
   osasto: 1
   ryhma: 10
   <<: *DEFAULTS
+
+huutokauppa_customer_1:
+  email: testit@testi.tes
+  <<: *DEFAULTS
+
+huutokauppa_customer_2:
+  email: te.testite@testi.tes
+  <<: *DEFAULTS

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -46,8 +46,20 @@ lissu:
 
 huutokauppa_customer_1:
   email: testit@testi.tes
+  gsm: +123 45 6789012
+  nimi: Testi Testit Testitestit
+  osoite: testitestit 12
+  postino: 12345
+  postitp: Testi
+  ytunnus: 279590
   <<: *DEFAULTS
 
 huutokauppa_customer_2:
   email: te.testite@testi.tes
+  gsm: +123 45 6789012
+  nimi: Test-testi Testite
+  osoite: Testitesti 123
+  postino: 23456
+  postitp: Testitesti
+  ytunnus: 270265
   <<: *DEFAULTS

--- a/test/fixtures/parameters.yml
+++ b/test/fixtures/parameters.yml
@@ -3,6 +3,7 @@ acme:
   css: "* { font-family: sans-serif }"
   maventa_aikaleima: <%= Time.now %>
   varastopaikkojen_maarittely: M
+  rahti_tuotenumero: RAHTI
   muuttaja: joe
   laatija: joe
   luontiaika: <%= Time.now %>

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -49,3 +49,10 @@ pr1:
   nimitys: Päiväraha
   tuotetyyppi: A
   <<: *DEFAULTS
+
+freight:
+  yhtio: acme
+  tuoteno: RAHTI
+  nimitys: Rahti
+  status: A
+  <<: *DEFAULTS

--- a/test/fixtures/sales_order/drafts.yml
+++ b/test/fixtures/sales_order/drafts.yml
@@ -1,4 +1,5 @@
 DEFAULTS: &DEFAULTS
+  tila: N
   luontiaika: <%= Time.now %>
   laatija: joe
   muutospvm: <%= Time.now %>
@@ -23,7 +24,13 @@ DEFAULTS: &DEFAULTS
 
 not_finished_order:
   yhtio: acme
-  tila: N
   alatila: ''
   terms_of_payment: hundred_days_net
   <<: *DEFAULTS
+
+<% [270265, 274472, 277075, 277687, 279590, 285888].each do |auction_id| %>
+huutokauppa_<%= auction_id %>:
+  yhtio: acme
+  viesti: <%= auction_id %>
+  <<: *DEFAULTS
+<% end %>

--- a/test/fixtures/sales_order/rows.yml
+++ b/test/fixtures/sales_order/rows.yml
@@ -12,3 +12,11 @@ so_row_one:
   tuoteno: hammer123
   tyyppi: L
   <<: *DEFAULTS
+
+<% [270265, 274472, 277075, 277687, 279590, 285888].each do |auction_id| %>
+huutokauppa_<%= auction_id %>_row_1:
+  order: huutokauppa_<%= auction_id %>
+  tuoteno: hammer123
+  tyyppi: L
+  <<: *DEFAULTS
+<% end %>

--- a/test/models/parameter_test.rb
+++ b/test/models/parameter_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
 
 class ParametersTest < ActiveSupport::TestCase
-  fixtures %w(parameters)
+  fixtures %w(
+    parameters
+    products
+  )
 
   setup do
     @acme_params = parameters(:acme)
@@ -15,4 +18,7 @@ class ParametersTest < ActiveSupport::TestCase
     assert_not_nil @acme_params.company
   end
 
+  test '.freight_product' do
+    assert_equal products(:freight), Parameter.freight_product
+  end
 end

--- a/test/models/parameter_test.rb
+++ b/test/models/parameter_test.rb
@@ -14,11 +14,8 @@ class ParametersTest < ActiveSupport::TestCase
     assert @acme_params.valid?, @acme_params.errors.messages
   end
 
-  test "params has a company" do
+  test "associations" do
     assert_not_nil @acme_params.company
-  end
-
-  test '.freight_product' do
-    assert_equal products(:freight), Parameter.freight_product
+    assert_not_nil @acme_params.freight_product
   end
 end

--- a/test/models/sales_order/draft_test.rb
+++ b/test/models/sales_order/draft_test.rb
@@ -1,13 +1,34 @@
+require 'minitest/mock'
 require 'test_helper'
 
 class SalesOrder::DraftTest < ActiveSupport::TestCase
   fixtures %w(
     sales_order/drafts
+    users
   )
+
+  setup do
+    Current.user = users(:bob)
+  end
 
   test 'fixtures are valid' do
     SalesOrder::Draft.all.each do |draft|
       assert draft.valid?
+    end
+  end
+
+  test '#mark_as_done' do
+    SalesOrder::Draft.all.each do |draft|
+      mark_as_done = proc do
+        draft.tila = 'L'
+        draft.save(validate: false)
+      end
+
+      LegacyMethods.stub(:pupesoft_function, mark_as_done) do
+        assert_difference 'SalesOrder::Draft.count', -1 do
+          draft.mark_as_done
+        end
+      end
     end
   end
 end

--- a/test/models/sales_order/draft_test.rb
+++ b/test/models/sales_order/draft_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class SalesOrder::DraftTest < ActiveSupport::TestCase
+  fixtures %w(
+    sales_order/drafts
+  )
+
+  test 'fixtures are valid' do
+    SalesOrder::Draft.all.each do |draft|
+      assert draft.valid?
+    end
+  end
+end


### PR DESCRIPTION
##### New instance methods to `HuutokauppaMail`

- `add_delivery_row_to_order`
- `create_customer`
- `create_sales_order`
- `delivery_price_without_vat`
- `delivery_price`
- `find_customer`
- `find_order`
- `update_customer`
- `update_order_customer_info`
- `update_order_delivery_info`
- `update_order_product_info`

##### New instance method to `SalesOrder`

- `mark_as_done`

##### New class method to `LegacyMethods` module

- `pupesoft_function`
  - Allows calling Pupesoft function from Pupenext dynamically. Functions need to be created to Pupesoft's rajapinnat/pupenext.php though, so that compatibility can be assured.

##### New class method to `Parameter`

- `freight_product`