### PR TITLE
HuutokauppaJob logic

### DIFF
--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -216,7 +216,9 @@ class HuutokauppaMail
   def create_sales_order
     return unless customer_name
 
-    response = LegacyMethods.pupesoft_function(:luo_myyntitilausotsikko, customer_id: find_customer.id)
+    customer_id = find_customer.try(:id) || create_customer.id
+
+    response = LegacyMethods.pupesoft_function(:luo_myyntitilausotsikko, customer_id: customer_id)
     sales_order_id = response[:sales_order_id]
 
     SalesOrder::Draft.find(sales_order_id)

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -173,6 +173,16 @@ class HuutokauppaMail
     )
   end
 
+  def update_or_create_customer
+    if find_customer
+      update_customer
+
+      return find_customer
+    end
+
+    create_customer
+  end
+
   def find_draft
     @draft ||= SalesOrder::Draft.find_by!(viesti: auction_id)
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -232,7 +232,7 @@ class HuutokauppaMail
     product = Product.where(tuoteno: DELIVERY_PRODUCT_NUMBERS)
                      .where('round(myyntihinta * 1.24, 2) >= ?', delivery_price_with_vat)
                      .order(:myyntihinta)
-                     .first
+                     .first!
 
     response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_order.id, product_id: product.id)
 

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -1,7 +1,7 @@
 class HuutokauppaMail
   attr_reader :mail
 
-  DELIVERY_PRODUCT_NUMBERS = (90..95).to_a + (90..95).to_a.map { |e| "#{e} max" }
+  DELIVERY_PRODUCT_NUMBERS = (90..95).to_a + (90..95).to_a.map { |e| "#{e}MAX" }
 
   def initialize(raw_source)
     raise 'Current company must be set' unless Current.company

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -141,7 +141,7 @@ class HuutokauppaMail
   end
 
   def find_customer
-    @customer ||= Customer.find_by!(email: customer_email) if customer_email
+    @customer ||= Customer.find_by(email: customer_email) if customer_email
   end
 
   def create_customer

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -173,14 +173,18 @@ class HuutokauppaMail
     )
   end
 
+  def find_draft
+    @draft ||= SalesOrder::Draft.find_by!(viesti: auction_id)
+  end
+
   def find_order
-    @order ||= SalesOrder::Draft.find_by(viesti: auction_id) || SalesOrder::Order.find_by!(viesti: auction_id)
+    @order ||= SalesOrder::Order.find_by!(viesti: auction_id)
   end
 
   def update_order_customer_info
     return unless customer_name
 
-    find_order.update!(
+    find_draft.update!(
       email: customer_email,
       nimi: customer_name,
       osoite: customer_address,
@@ -204,7 +208,7 @@ class HuutokauppaMail
   end
 
   def update_order_product_info
-    find_order.rows.first.update!(
+    find_draft.rows.first.update!(
       alv: auction_vat_percent,
       hinta: auction_price_without_vat,
       hinta_alkuperainen: auction_price_without_vat,
@@ -234,9 +238,9 @@ class HuutokauppaMail
                      .order(:myyntihinta)
                      .first!
 
-    response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_order.id, product_id: product.id)
+    response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_draft.id, product_id: product.id)
 
-    find_order.rows.find(response[:added_row])
+    find_draft.rows.find(response[:added_row])
   end
 
   private

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -247,6 +247,10 @@ class HuutokauppaMail
     find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
   end
 
+  def mark_as_done
+    find_draft.mark_as_done
+  end
+
   private
 
     def customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -247,6 +247,10 @@ class HuutokauppaMail
     find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
   end
 
+  def update_delivery_method_to_itella_economy_16
+    find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
+  end
+
   def mark_as_done
     find_draft.mark_as_done
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -224,18 +224,12 @@ class HuutokauppaMail
     SalesOrder::Draft.find(sales_order_id)
   end
 
-  def add_delivery_row_to_order(order)
+  def add_delivery_row
     return unless delivery_price_without_vat
 
-    order.rows.create!(
-      alv: delivery_vat_percent,
-      hinta: delivery_price_without_vat,
-      hinta_alkuperainen: delivery_price_without_vat,
-      hinta_valuutassa: delivery_price_without_vat,
-      product: order.company.parameter.freight_product,
-      rivihinta: delivery_price_without_vat,
-      rivihinta_valuutassa: delivery_price_without_vat,
-    )
+    response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_order.id, product_id: 709_519)
+
+    find_order.rows.find(response[:added_row])
   end
 
   private

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -174,7 +174,7 @@ class HuutokauppaMail
   end
 
   def find_order
-    @order ||= SalesOrder::Draft.find_by!(viesti: auction_id)
+    @order ||= SalesOrder::Draft.find_by(viesti: auction_id) || SalesOrder::Order.find_by!(viesti: auction_id)
   end
 
   def update_order_customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -243,6 +243,10 @@ class HuutokauppaMail
     find_draft.rows.find(response[:added_row])
   end
 
+  def update_delivery_method_to_nouto
+    find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
+  end
+
   private
 
     def customer_info

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -22,8 +22,7 @@ class HuutokauppaJob < ActiveJob::Base
   private
 
     def update_order_customer_and_product_info
-      customer = @huutokauppa_mail.find_customer || @huutokauppa_mail.create_customer
-
+      @huutokauppa_mail.update_or_create_customer
       @huutokauppa_mail.update_order_customer_info
       @huutokauppa_mail.update_order_product_info
 

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -5,7 +5,7 @@ class HuutokauppaJob < ActiveJob::Base
     incoming_mail = IncomingMail.find(id)
 
     Current.company = incoming_mail.company
-    Current.user    = Current.company.users.find_by(kuka: 'admin')
+    Current.user    = Current.company.users.find_by!(kuka: 'admin')
 
     incoming_mail.update(
       processed_at: Time.now,

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -41,6 +41,9 @@ class HuutokauppaJob < ActiveJob::Base
       @huutokauppa_mail.find_order.update!(
         delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'),
       )
+
+      @huutokauppa_mail.add_delivery_row
+
       @huutokauppa_mail.find_order.mark_as_done
     end
 end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -2,24 +2,30 @@ class HuutokauppaJob < ActiveJob::Base
   queue_as :huutokauppa
 
   def perform(id:)
-    incoming_mail = IncomingMail.find(id)
+    @incoming_mail = IncomingMail.find(id)
 
-    Current.company = incoming_mail.company
+    Current.company = @incoming_mail.company
     Current.user    = Current.company.users.find_by!(kuka: 'admin')
 
-    huutokauppa_mail = HuutokauppaMail.new(incoming_mail.raw_source)
+    @huutokauppa_mail = HuutokauppaMail.new(@incoming_mail.raw_source)
 
-    case huutokauppa_mail.type
+    case @huutokauppa_mail.type
     when :offer_accepted, :offer_automatically_accepted
-      customer = huutokauppa_mail.find_customer || huutokauppa_mail.create_customer
+      update_order_customer_and_product_info
+    end
+  end
 
-      huutokauppa_mail.update_order_customer_info
-      huutokauppa_mail.update_order_product_info
+  private
 
-      incoming_mail.update(
+    def update_order_customer_and_product_info
+      customer = @huutokauppa_mail.find_customer || @huutokauppa_mail.create_customer
+
+      @huutokauppa_mail.update_order_customer_info
+      @huutokauppa_mail.update_order_product_info
+
+      @incoming_mail.update(
         processed_at: Time.now,
         status: :ok,
       )
     end
-  end
 end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -23,9 +23,15 @@ class HuutokauppaJob < ActiveJob::Base
       @huutokauppa_mail.update_order_customer_info
       @huutokauppa_mail.update_order_product_info
 
-      @incoming_mail.update(
+      @incoming_mail.update!(
         processed_at: Time.now,
         status: :ok,
+      )
+    rescue => e
+      @incoming_mail.update!(
+        processed_at: Time.now,
+        status: :error,
+        status_message: e.message,
       )
     end
 end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -14,6 +14,8 @@ class HuutokauppaJob < ActiveJob::Base
       update_order_customer_and_product_info
     when :purchase_price_paid
       mark_order_as_done_and_set_delivery_method
+    when :delivery_ordered
+      update_order_delivery_info_and_delivery_method
     end
   end
 
@@ -38,12 +40,13 @@ class HuutokauppaJob < ActiveJob::Base
     end
 
     def mark_order_as_done_and_set_delivery_method
-      @huutokauppa_mail.find_order.update!(
-        delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'),
-      )
-
+      @huutokauppa_mail.find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
       @huutokauppa_mail.add_delivery_row
-
       @huutokauppa_mail.find_order.mark_as_done
+    end
+
+    def update_order_delivery_info_and_delivery_method
+      @huutokauppa_mail.update_order_delivery_info
+      @huutokauppa_mail.find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
     end
 end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -36,9 +36,9 @@ class HuutokauppaJob < ActiveJob::Base
     end
 
     def mark_order_as_done_and_set_delivery_method
-      @huutokauppa_mail.find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
+      @huutokauppa_mail.find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
       @huutokauppa_mail.add_delivery_row
-      @huutokauppa_mail.find_order.mark_as_done
+      @huutokauppa_mail.find_draft.mark_as_done
     rescue => e
       log_error(e)
     end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -45,7 +45,7 @@ class HuutokauppaJob < ActiveJob::Base
 
     def update_order_delivery_info_and_delivery_method
       @huutokauppa_mail.update_order_delivery_info
-      @huutokauppa_mail.find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
+      @huutokauppa_mail.update_delivery_method_to_itella_economy_16
     rescue => e
       log_error(e)
     end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -12,6 +12,8 @@ class HuutokauppaJob < ActiveJob::Base
     case @huutokauppa_mail.type
     when :offer_accepted, :offer_automatically_accepted
       update_order_customer_and_product_info
+    when :purchase_price_paid
+      mark_order_as_done_and_set_delivery_method
     end
   end
 
@@ -33,5 +35,12 @@ class HuutokauppaJob < ActiveJob::Base
         status: :error,
         status_message: e.message,
       )
+    end
+
+    def mark_order_as_done_and_set_delivery_method
+      @huutokauppa_mail.find_order.update!(
+        delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'),
+      )
+      @huutokauppa_mail.find_order.mark_as_done
     end
 end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -32,21 +32,29 @@ class HuutokauppaJob < ActiveJob::Base
         status: :ok,
       )
     rescue => e
-      @incoming_mail.update!(
-        processed_at: Time.now,
-        status: :error,
-        status_message: e.message,
-      )
+      log_error(e)
     end
 
     def mark_order_as_done_and_set_delivery_method
       @huutokauppa_mail.find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
       @huutokauppa_mail.add_delivery_row
       @huutokauppa_mail.find_order.mark_as_done
+    rescue => e
+      log_error(e)
     end
 
     def update_order_delivery_info_and_delivery_method
       @huutokauppa_mail.update_order_delivery_info
       @huutokauppa_mail.find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
+    rescue => e
+      log_error(e)
+    end
+
+    def log_error(exception)
+      @incoming_mail.update!(
+        processed_at: Time.now,
+        status: :error,
+        status_message: exception.message,
+      )
     end
 end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -4,6 +4,9 @@ class HuutokauppaJob < ActiveJob::Base
   def perform(id:)
     incoming_mail = IncomingMail.find(id)
 
+    Current.company = incoming_mail.company
+    Current.user    = Current.company.users.find_by(kuka: 'admin')
+
     incoming_mail.update(
       processed_at: Time.now,
       status: :ok

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -7,9 +7,19 @@ class HuutokauppaJob < ActiveJob::Base
     Current.company = incoming_mail.company
     Current.user    = Current.company.users.find_by!(kuka: 'admin')
 
-    incoming_mail.update(
-      processed_at: Time.now,
-      status: :ok
-    )
+    huutokauppa_mail = HuutokauppaMail.new(incoming_mail.raw_source)
+
+    case huutokauppa_mail.type
+    when :offer_accepted, :offer_automatically_accepted
+      customer = huutokauppa_mail.find_customer || huutokauppa_mail.create_customer
+
+      huutokauppa_mail.update_order_customer_info
+      huutokauppa_mail.update_order_product_info
+
+      incoming_mail.update(
+        processed_at: Time.now,
+        status: :ok,
+      )
+    end
   end
 end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -36,7 +36,7 @@ class HuutokauppaJob < ActiveJob::Base
     end
 
     def mark_order_as_done_and_set_delivery_method
-      @huutokauppa_mail.find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
+      @huutokauppa_mail.update_delivery_method_to_nouto
       @huutokauppa_mail.add_delivery_row
       @huutokauppa_mail.find_draft.mark_as_done
     rescue => e

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -9,14 +9,21 @@ class HuutokauppaJob < ActiveJob::Base
 
     @huutokauppa_mail = HuutokauppaMail.new(@incoming_mail.raw_source)
 
-    case @huutokauppa_mail.type
-    when :offer_accepted, :offer_automatically_accepted
-      update_order_customer_and_product_info
-    when :purchase_price_paid
-      mark_order_as_done_and_set_delivery_method
-    when :delivery_ordered
-      update_order_delivery_info_and_delivery_method
-    end
+    success = case @huutokauppa_mail.type
+              when :offer_accepted, :offer_automatically_accepted
+                update_order_customer_and_product_info
+              when :purchase_price_paid
+                mark_order_as_done_and_set_delivery_method
+              when :delivery_ordered
+                update_order_delivery_info_and_delivery_method
+              end
+
+    return false unless success
+
+    @incoming_mail.update!(
+      processed_at: Time.now,
+      status: :ok,
+    )
   end
 
   private
@@ -25,28 +32,29 @@ class HuutokauppaJob < ActiveJob::Base
       @huutokauppa_mail.update_or_create_customer
       @huutokauppa_mail.update_order_customer_info
       @huutokauppa_mail.update_order_product_info
-
-      @incoming_mail.update!(
-        processed_at: Time.now,
-        status: :ok,
-      )
+      true
     rescue => e
       log_error(e)
+      false
     end
 
     def mark_order_as_done_and_set_delivery_method
       @huutokauppa_mail.update_delivery_method_to_nouto
       @huutokauppa_mail.add_delivery_row
       @huutokauppa_mail.mark_as_done
+      true
     rescue => e
       log_error(e)
+      false
     end
 
     def update_order_delivery_info_and_delivery_method
       @huutokauppa_mail.update_order_delivery_info
       @huutokauppa_mail.update_delivery_method_to_itella_economy_16
+      true
     rescue => e
       log_error(e)
+      false
     end
 
     def log_error(exception)

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -38,7 +38,7 @@ class HuutokauppaJob < ActiveJob::Base
     def mark_order_as_done_and_set_delivery_method
       @huutokauppa_mail.update_delivery_method_to_nouto
       @huutokauppa_mail.add_delivery_row
-      @huutokauppa_mail.find_draft.mark_as_done
+      @huutokauppa_mail.mark_as_done
     rescue => e
       log_error(e)
     end

--- a/app/models/delivery_method.rb
+++ b/app/models/delivery_method.rb
@@ -1,6 +1,10 @@
 class DeliveryMethod < BaseModel
   belongs_to :company, foreign_key: :yhtio, primary_key: :yhtio
-  has_many :customers, foreign_key: :toimitustapa, primary_key: :selite
+
+  with_options foreign_key: :toimitustapa, primary_key: :selite do |o|
+    o.has_many :customers
+    o.has_many :sales_orders, class_name: 'SalesOrder::Order'
+  end
 
   self.table_name = :toimitustapa
   self.primary_key = :tunnus

--- a/app/models/head.rb
+++ b/app/models/head.rb
@@ -6,6 +6,7 @@ class Head < BaseModel
   self.inheritance_column = :tila
 
   belongs_to :terms_of_payment, foreign_key: :maksuehto
+  belongs_to :delivery_method, foreign_key: :toimitustapa, primary_key: :selite
   has_many :accounting_rows, class_name: 'Head::VoucherRow', foreign_key: :ltunnus
 
   scope :paid, -> { where.not(mapvm: 0) }

--- a/test/assets/huutokauppa_emails/purchase_price_paid_2
+++ b/test/assets/huutokauppa_emails/purchase_price_paid_2
@@ -1,0 +1,69 @@
+Return-path: <bounces@automated.huutokaupat.com>
+Envelope-to: testite@testi.te
+Delivery-date: Tue, 26 Apr 2016 20:56:18 +0300
+Received: from filter2.hostingservice.fi ([31.217.192.174]:38176)
+    by cloud13.hostingpalvelu.fi with esmtps (TLSv1.2:ECDHE-RSA-AES256-GCM-SHA384:256)
+    (Exim 4.86_1)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1av7Dc-004KXa-K7; Tue, 26 Apr 2016 20:56:16 +0300
+Received: from server.huutokaupat.com ([83.150.76.4])
+    by filter2.hostingservice.fi with esmtp (Exim 4.85)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1av7DZ-0007X5-4g; Tue, 26 Apr 2016 20:56:13 +0300
+Received: from localhost (unknown [10.10.10.129])
+    by server.huutokaupat.com (Postfix) with ESMTP id DA970200613;
+    Tue, 26 Apr 2016 20:56:12 +0300 (EEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=huutokaupat.com;
+    s=default; t=1461693372;
+    bh=p//2SwaiYVI4dUNBsXdwCvrLxAGYgtdvXNY82xp2Ogc=;
+    h=From:To:Subject:Date;
+    b=QEsD4vhUMZDk0jPx4NAIUki9hwYp+JFZGYV9eOu+BItV14xhUGNdBYqc56aOWMEZs
+     iLum4SIKHDKIFLxGqq3PzBMD9ZMWbvGdsvy6qJvy0tjyOeRLxnYFYX2N9TXM3vEjf+
+     fA+dZ3QGw6LzRYdjhDUdv8gz+BFonZpKxt96F2Zw=
+From: "Huutokaupat.com" <asiakaspalvelu@huutokaupat.com>
+To: testite@testi.te
+Subject: Kauppahinta maksettu Huutokaupat.com nettihuutokauppa: kohde #287912
+Date: Tue, 26 Apr 2016 20:56:12 +0300
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+MIME-Version: 1.0
+X-Filter-ID: s0sct1PQhAABKnZB5plbIeAyHwHIceqjIqYzluv0NUpuO2tWUqBCEbdShNj29n29hTQlI8BJQNwf
+ dZmIYTr6GnVEJQAYV9ff1+lJ+Sf2nQ3k+GDP+f6xF7XLnlq3j2ne/5FdbgtqnqT56S7k+tyLwZHf
+ WZYD82R/uX1kWNJz4wES3dsoT4fYpUWtq2l6tT6ampYbIWehzfMhBX2xrya8NiYD1ptUVn6ByrDO
+ Wen4bPcvcplYN5zMlHdXzOu7gRr7JZBJUDyXddX3lRgqX8VJ+tAeq+cds6nJlNErvZtFoqBG5Tpk
+ D/Jv7PkKJQMLl7iniwQzKw+6v3CaIMG6s7LqJAIIBVgPWFQrNNt4skZxEXKQm4E4p26nSSkPphfX
+ rBhTiG4XwpsXfeh5n1ZI7qO6rgm3sj9lmtbo8r2I2S7vXK6qfnfiHkB4epRqIBEW9yvDe+rrxbVY
+ RI5qM5mkwzDs9idlTZ/1FHjgq2v1uRnTIQkzjyjL/QuDtdf6sFzW2z/xrZ1imVBgEPlWeT9NV68R
+ zTGyrcyC2vCRmxz47BFeriZoD7bAeKsWl/oNzWdtNsPTrUXX5D+Zk7NvU6DQewiNCincCmK8uaqK
+ pmdh0n2Qm1Vxy/ihLCT5uxnmHhGGy2O3GwTuewy/HmZZ5Q1Q/X20UmtnqtxYC4A8Mpq5s+pEiB7R
+ rozQuRVmTz0MvEjBP3L2CCqB9MF1QnIcvR4Oc30Set++dzS2U7nKMHPJjR66Knzy8PsbvOGQC8Rk
+ xXXi70l4QCjD5CFhDgWZDuq0TejmL1C6yAg7PQlNtgw29ArPlaU=
+X-Report-Abuse-To: spam@filter1.hostingservice.fi
+Authentication-Results: hostingservice.fi; dkim=pass header.i=huutokaupat.com
+X-SpamExperts-Class: whitelisted
+X-SpamExperts-Evidence: sender
+X-Recommended-Action: accept
+
+<p>=0A    Vahvistamme t=C3=A4ten ett=C3=A4 ostaja on maksanut kauppahinn=
+an asiakastilillemme seuraavasta kohteesta ja se voidaan luovuttaa ostaj=
+alle:=0A</p>=0A=0A<p>=0A    Kohde #287912<br/>=0A    Otsikkokentt=C3=A4:=
+ 17.04.-23.04. Tunkkisetti. 20-30 tonnia, UUSIA, Lahti<br/>=0A    P=C3=
+=A4=C3=A4ttymisaika: Lauantai 23.04.2016 klo 19:40<br/>=0A    Huudettu:=
+ 200 EUR<br/>=0A    Alv-osuus: 48.00 EUR<br/>=0A    Summa: 248.00 EUR, A=
+LV 24 %<br/>=0A            Nouto: 0.00 EUR, ALV 24 %, ALV-osuus 0 EUR<br=
+>=0A        Yhteens=C3=A4: 248 EUR<br>=0A    </p>=0A=0A<p>=0A    Ostajan=
+ yhteystiedot:<br/>=0A        Test testit Testi<br/>=0A    test.testi@te=
+stitestit.fi<br/>=0A            Puhelin: +123 45 6789012<br/>=0A       =
+ Osoite:<br/>=0A    Testitest 21<br/>=0A    12345 Testi<br/>=0A    Suomi=
+=0A</p>=0A=0A<p>=0A    Myyj=C3=A4n/toimeksisaaneen yhteystiedot:<br/>=0A=
+    Testi Testitest<br />=0AY-tunnus: 1234567-8<br />=0ARahti tilaukset<=
+br />=testites@testi.te<br />=0A<br />=0A<br />=0AIlmoittajan viite: 435=
+-100<br />=0A<br/>=0A    <br/>=0A    Huutokaupan tilana n=C3=A4kyy ilmoi=
+tuksessa: Myyty.<br/>=0A    <br/>=0A    Tulemme suorittamaan kauppahinna=
+n ilmoittamallenne tilille viimeist=C3=A4=C3=A4n seitsem=C3=A4n seuraava=
+n arkip=C3=A4iv=C3=A4n aikana.<br/>=0A    <br/>=0A    Myyntikohde n=C3=
+=A4kyy myynnin toteuduttua sivuilla 7 p=C3=A4iv=C3=A4=C3=A4 ja poistuu t=
+=C3=A4m=C3=A4n j=C3=A4lkeen sivuilta automaattisesti.=0A</p>=0A=0A<p>=0A=
+    Yst=C3=A4v=C3=A4llisin terveisin,<br/>=0AHuutokaupat.com=0A=0A</p>=
+=0A

--- a/test/assets/huutokauppa_emails/purchase_price_paid_3
+++ b/test/assets/huutokauppa_emails/purchase_price_paid_3
@@ -1,0 +1,61 @@
+Return-path: <bounces@automated.huutokaupat.com>
+Envelope-to: testite@testi.te
+Delivery-date: Tue, 26 Apr 2016 20:29:22 +0300
+Received: from filter1.hostingservice.fi ([31.217.192.66]:44382)
+    by cloud13.hostingpalvelu.fi with esmtps (TLSv1.2:ECDHE-RSA-AES256-GCM-SHA384:256)
+    (Exim 4.86_1)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1av6nT-004GYu-Eh; Tue, 26 Apr 2016 20:29:15 +0300
+Received: from server.huutokaupat.com ([83.150.76.4])
+    by filter1.hostingservice.fi with esmtp (Exim 4.85)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1av6nP-0002GI-Tt; Tue, 26 Apr 2016 20:29:12 +0300
+Received: from localhost (unknown [10.10.10.128])
+    by server.huutokaupat.com (Postfix) with ESMTP id 85238200620;
+    Tue, 26 Apr 2016 20:29:11 +0300 (EEST)
+From: "Huutokaupat.com" <asiakaspalvelu@huutokaupat.com>
+To: testite@testi.te
+Subject: Kauppahinta maksettu Huutokaupat.com nettihuutokauppa: kohde #285703
+Date: Tue, 26 Apr 2016 20:29:11 +0300
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+MIME-Version: 1.0
+X-Filter-ID: s0sct1PQhAABKnZB5plbIeAyHwHIceqjIqYzluv0NUpuO2tWUqBCEbdShNj29n29hTQlI8BJQNwf
+ dZmIYTr6GnVEJQAYV9ff1+lJ+Sf2nQ3k+GDP+f6xF7XLnlq3j2ne/5FdbgtqnqT56S7k+tyLwZHf
+ WZYD82R/uX1kWNJz4wES3dsoT4fYpUWtq2l6tT6ampYbIWehzfMhBX2xrya8NiYD1ptUVn6ByrDO
+ Wen4bPcvcplYN5zMlHdXzOu7gRr7JZBJUDyXddX3lRgqX8VJ+tAeq+cds6nJlNErvZtFoqBG5Tpk
+ D/Jv7PkKJQMLl7iniwQzKw+6v3CaIMG6s7LqJAIIBVgPWFQrNNt4skZxEXKQm4E4p26nSSkPphfX
+ rBhTiG4XwpsXfeh5n1ZI7qO6rgm3sj9lmtbo8r2I2S7vXK7EEtmebq6SxoxWzbCMDUfPe+rrxbVY
+ RI5qM5mkwzDs9idlTZ/1FHjgq2v1uRnTIQkzjyjL/QuDtdf6sFzW2z/xrZ1imVBgEPlWeT9NV68R
+ zTGyrcyC2vCRmxz47BFeriZoD7bAeKsWl/oNzWdtNsPTrUXX5D+Zk7NvU6DQewiNCincCmK8uaqK
+ pmdh0n2Qm1Vxy/ihLCT5uxnmHhGGy2O3GwTuewy/HmZZ5Q1Q/X20UmtnqtxYC4A8Mpq5s+pEiB7R
+ rozQuRVmTz0MvEjBP3L2OxghKP7tVQq5YTeMT8WxHt++dzS2U7nKMHPJjR66Knzy8PsbvOGQC8Rk
+ xXXi70l4M3LcgKsHtBPT9eybimHz1KgbEdlpyxJNDXxt69fsQnI=
+X-Report-Abuse-To: spam@filter1.hostingservice.fi
+X-SpamExperts-Class: whitelisted
+X-SpamExperts-Evidence: sender
+X-Recommended-Action: accept
+
+<p>=0A    Vahvistamme t=C3=A4ten ett=C3=A4 ostaja on maksanut kauppahinn=
+an asiakastilillemme seuraavasta kohteesta ja se voidaan luovuttaa ostaj=
+alle:=0A</p>=0A=0A<p>=0A    Kohde #285703<br/>=0A    Otsikkokentt=C3=A4:=
+ 24.04.-26.04. KAPPA reppu + KAPPA treenikassi + KAPPA sukat, UUSIA, Lah=
+ti<br/>=0A    P=C3=A4=C3=A4ttymisaika: Tiistai 26.04.2016 klo 19:46<br/>=
+=0A    Huudettu: 60 EUR<br/>=0A    Alv-osuus: 14.40 EUR<br/>=0A    Summa=
+: 74.40 EUR, ALV 24 %<br/>=0A            Toimitus: 17.95 EUR, ALV 24 %,=
+ ALV-osuus 3.48 EUR<br>=0A        Yhteens=C3=A4: 92.35 EUR<br>=0A    </p=
+>=0A=0A<p>=0A    Ostajan yhteystiedot:<br/>=0A        Test test testi Te=
+stite<br/>=0A    testite@testite.tes<br/>=0A            Puhelin: +123 45=
+ 6789012<br/>=0A        Osoite:<br/>=0A    Testite=C3=A4ki 12 A 1<br/>=
+=0A    12345 testite<br/>=0A    Suomi=0A</p>=0A=0A<p>=0A    Myyj=C3=A4n/=
+toimeksisaaneen yhteystiedot:<br/>=0A    Testi Testitest<br />=0AY-tunnu=
+s: 1234567-8<br />=0ARahti tilaukset<br />=testites@testi.te<br />=0A<br=
+ />=0A<br />=0AIlmoittajan viite: 626-100<br />=0A<br/>=0A    <br/>=0A =
+   Huutokaupan tilana n=C3=A4kyy ilmoituksessa: Myyty.<br/>=0A    <br/>=
+=0A    Tulemme suorittamaan kauppahinnan ilmoittamallenne tilille viimei=
+st=C3=A4=C3=A4n seitsem=C3=A4n seuraavan arkip=C3=A4iv=C3=A4n aikana.<br=
+/>=0A    <br/>=0A    Myyntikohde n=C3=A4kyy myynnin toteuduttua sivuilla=
+ 7 p=C3=A4iv=C3=A4=C3=A4 ja poistuu t=C3=A4m=C3=A4n j=C3=A4lkeen sivuilt=
+a automaattisesti.=0A</p>=0A=0A<p>=0A    Yst=C3=A4v=C3=A4llisin terveisi=
+n,<br/>=0AHuutokaupat.com=0A=0A</p>=0A

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -618,6 +618,26 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#update_delivery_method_to_itella_economy_16' do
+    [
+      @auction_ended,
+      @bidder_picks_up,
+      @delivery_offer_request,
+      @delivery_ordered,
+      @offer_accepted,
+      @offer_declined,
+      @purchase_price_paid_2,
+      @purchase_price_paid_3,
+    ].each do |email|
+      draft = email.find_draft
+      draft.tila = 'L'
+      draft.save(validate: false)
+
+      email.update_delivery_method_to_itella_economy_16
+      assert_equal delivery_methods(:itella_economy_16), email.find_order.delivery_method
+    end
+  end
+
   test '#mark_as_done' do
     [
       @auction_ended,

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -562,9 +562,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#add_delivery_row' do
     [
-      @bidder_picks_up,
       @delivery_ordered,
-      @purchase_price_paid_2,
       @purchase_price_paid_3,
     ].each do |email|
       create_row = proc do
@@ -583,11 +581,13 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
     [
       @auction_ended,
+      @bidder_picks_up,
       @delivery_offer_request,
       @offer_accepted,
       @offer_automatically_accepted,
       @offer_declined,
       @purchase_price_paid,
+      @purchase_price_paid_2,
     ].each do |email|
       assert_no_difference 'Row.count' do
         email.add_delivery_row

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -665,4 +665,28 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test '#update_or_create_customer' do
+    [
+      @offer_accepted,
+      @offer_automatically_accepted,
+      @purchase_price_paid,
+    ].each do |email|
+      assert_no_difference 'Customer.count' do
+        customer = email.update_or_create_customer
+
+        assert_equal email.find_customer, customer
+        assert_equal email.customer_name, customer.nimi
+      end
+    end
+
+    [
+      @purchase_price_paid_2,
+      @purchase_price_paid_3,
+    ].each do |email|
+      assert_difference 'Customer.count' do
+        email.update_or_create_customer
+      end
+    end
+  end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -598,4 +598,22 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test '#update_delivery_method_to_nouto' do
+    [
+      @auction_ended,
+      @bidder_picks_up,
+      @delivery_offer_request,
+      @delivery_ordered,
+      @offer_accepted,
+      @offer_automatically_accepted,
+      @offer_declined,
+      @purchase_price_paid,
+      @purchase_price_paid_2,
+      @purchase_price_paid_3,
+    ].each do |email|
+      email.update_delivery_method_to_nouto
+      assert_equal delivery_methods(:nouto), email.find_draft.delivery_method
+    end
+  end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -453,17 +453,17 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
-  test '#find_order' do
-    assert_equal sales_order_drafts(:huutokauppa_279590), @auction_ended.find_order
-    assert_equal sales_order_drafts(:huutokauppa_285888), @bidder_picks_up.find_order
-    assert_equal sales_order_drafts(:huutokauppa_270265), @delivery_offer_request.find_order
-    assert_equal sales_order_drafts(:huutokauppa_274472), @delivery_ordered.find_order
-    assert_equal sales_order_drafts(:huutokauppa_277075), @offer_accepted.find_order
-    assert_equal sales_order_drafts(:huutokauppa_270265), @offer_automatically_accepted.find_order
-    assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_order
-    assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_order
-    assert_equal sales_order_drafts(:huutokauppa_287912), @purchase_price_paid_2.find_order
-    assert_equal sales_order_drafts(:huutokauppa_285703), @purchase_price_paid_3.find_order
+  test '#find_draft' do
+    assert_equal sales_order_drafts(:huutokauppa_279590), @auction_ended.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_285888), @bidder_picks_up.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_270265), @delivery_offer_request.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_274472), @delivery_ordered.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_277075), @offer_accepted.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_270265), @offer_automatically_accepted.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_287912), @purchase_price_paid_2.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_285703), @purchase_price_paid_3.find_draft
   end
 
   test '#update_order_customer_info' do
@@ -476,12 +476,12 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     ].each do |email|
       assert email.update_order_customer_info
 
-      assert_equal email.customer_address,  email.find_order.osoite
-      assert_equal email.customer_city,     email.find_order.postitp
-      assert_equal email.customer_email,    email.find_order.email
-      assert_equal email.customer_name,     email.find_order.nimi
-      assert_equal email.customer_phone,    email.find_order.puh
-      assert_equal email.customer_postcode, email.find_order.postino
+      assert_equal email.customer_address,  email.find_draft.osoite
+      assert_equal email.customer_city,     email.find_draft.postitp
+      assert_equal email.customer_email,    email.find_draft.email
+      assert_equal email.customer_name,     email.find_draft.nimi
+      assert_equal email.customer_phone,    email.find_draft.puh
+      assert_equal email.customer_postcode, email.find_draft.postino
     end
 
     @emails_without_customer_info.each do |email|
@@ -491,6 +491,10 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#update_order_delivery_info' do
     [@delivery_offer_request, @delivery_ordered].each do |email|
+      draft = email.find_draft
+      draft.tila = 'L'
+      draft.save(validate: false)
+
       assert email.update_order_delivery_info
 
       assert_equal email.delivery_address,  email.find_order.toim_osoite
@@ -521,13 +525,13 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     ].each do |email|
       assert email.update_order_product_info
 
-      assert_equal email.auction_price_without_vat, email.find_order.rows.first.hinta
-      assert_equal email.auction_price_without_vat, email.find_order.rows.first.hinta_alkuperainen
-      assert_equal email.auction_price_without_vat, email.find_order.rows.first.hinta_valuutassa
-      assert_equal email.auction_price_without_vat, email.find_order.rows.first.rivihinta
-      assert_equal email.auction_price_without_vat, email.find_order.rows.first.rivihinta_valuutassa
-      assert_equal email.auction_title,             email.find_order.rows.first.nimitys
-      assert_equal email.auction_vat_percent,       email.find_order.rows.first.alv
+      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.hinta
+      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.hinta_alkuperainen
+      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.hinta_valuutassa
+      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.rivihinta
+      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.rivihinta_valuutassa
+      assert_equal email.auction_title,             email.find_draft.rows.first.nimitys
+      assert_equal email.auction_vat_percent,       email.find_draft.rows.first.alv
     end
   end
 
@@ -566,7 +570,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @purchase_price_paid_3,
     ].each do |email|
       create_row = proc do
-        row = email.find_order.rows.build
+        row = email.find_draft.rows.build
         row.save(validate: false)
 
         { added_row: row.id }

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -28,6 +28,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     @offer_automatically_accepted = HuutokauppaMail.new huutokauppa_email(:offer_automatically_accepted_1)
     @offer_declined               = HuutokauppaMail.new huutokauppa_email(:offer_declined_1)
     @purchase_price_paid          = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_1)
+    @purchase_price_paid_2        = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_2)
+    @purchase_price_paid_3        = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_3)
 
     @emails_without_customer_info = [
       @auction_ended,
@@ -44,6 +46,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_automatically_accepted,
       @offer_declined,
       @purchase_price_paid,
+      @purchase_price_paid_2,
+      @purchase_price_paid_3,
     ]
   end
 
@@ -79,12 +83,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal :offer_automatically_accepted, @offer_automatically_accepted.type
     assert_equal :offer_declined,               @offer_declined.type
     assert_equal :purchase_price_paid,          @purchase_price_paid.type
+    assert_equal :purchase_price_paid,          @purchase_price_paid_2.type
+    assert_equal :purchase_price_paid,          @purchase_price_paid_3.type
   end
 
   test '#customer_name' do
     assert_equal 'Testi Testit Testitestit', @offer_accepted.customer_name
     assert_equal 'Test-testi Testite',       @offer_automatically_accepted.customer_name
     assert_equal 'Test-testi Testite',       @purchase_price_paid.customer_name
+    assert_equal 'Test testit Testi',        @purchase_price_paid_2.customer_name
+    assert_equal 'Test test testi Testite',  @purchase_price_paid_3.customer_name
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_name
@@ -96,9 +104,11 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#customer_email' do
-    assert_equal 'testit@testi.tes',     @offer_accepted.customer_email
-    assert_equal 'te.testite@testi.tes', @offer_automatically_accepted.customer_email
-    assert_equal 'te.testite@testi.tes', @purchase_price_paid.customer_email
+    assert_equal 'testit@testi.tes',          @offer_accepted.customer_email
+    assert_equal 'te.testite@testi.tes',      @offer_automatically_accepted.customer_email
+    assert_equal 'te.testite@testi.tes',      @purchase_price_paid.customer_email
+    assert_equal 'test.testi@testitestit.fi', @purchase_price_paid_2.customer_email
+    assert_equal 'testite@testite.tes',       @purchase_price_paid_3.customer_email
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_email
@@ -109,6 +119,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '+123 45 6789012', @offer_accepted.customer_phone
     assert_equal '+123 45 6789012', @offer_automatically_accepted.customer_phone
     assert_equal '+123 45 6789012', @purchase_price_paid.customer_phone
+    assert_equal '+123 45 6789012', @purchase_price_paid_2.customer_phone
+    assert_equal '+123 45 6789012', @purchase_price_paid_3.customer_phone
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_phone
@@ -116,9 +128,11 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#customer_address' do
-    assert_equal 'testitestit 12', @offer_accepted.customer_address
-    assert_equal 'Testitesti 123', @offer_automatically_accepted.customer_address
-    assert_equal 'Testitesti 123', @purchase_price_paid.customer_address
+    assert_equal 'testitestit 12',    @offer_accepted.customer_address
+    assert_equal 'Testitesti 123',    @offer_automatically_accepted.customer_address
+    assert_equal 'Testitesti 123',    @purchase_price_paid.customer_address
+    assert_equal 'Testitest 21',      @purchase_price_paid_2.customer_address
+    assert_equal 'Testiteäki 12 A 1', @purchase_price_paid_3.customer_address
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_address
@@ -129,6 +143,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '12345', @offer_accepted.customer_postcode
     assert_equal '23456', @offer_automatically_accepted.customer_postcode
     assert_equal '12345', @purchase_price_paid.customer_postcode
+    assert_equal '12345', @purchase_price_paid_2.customer_postcode
+    assert_equal '12345', @purchase_price_paid_3.customer_postcode
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_postcode
@@ -139,6 +155,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 'Testi',      @offer_accepted.customer_city
     assert_equal 'Testitesti', @offer_automatically_accepted.customer_city
     assert_equal 'Testitesti', @purchase_price_paid.customer_city
+    assert_equal 'Testi',      @purchase_price_paid_2.customer_city
+    assert_equal 'testite',    @purchase_price_paid_3.customer_city
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_city
@@ -149,6 +167,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 'Suomi', @offer_accepted.customer_country
     assert_equal 'Suomi', @offer_automatically_accepted.customer_country
     assert_equal 'Suomi', @purchase_price_paid.customer_country
+    assert_equal 'Suomi', @purchase_price_paid_2.customer_country
+    assert_equal 'Suomi', @purchase_price_paid_3.customer_country
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_country
@@ -210,8 +230,10 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#delivery_price_without_vat' do
-    assert_equal 0,     @bidder_picks_up.delivery_price_without_vat
+    assert_equal 0.0,   @bidder_picks_up.delivery_price_without_vat
     assert_equal 14.47, @delivery_ordered.delivery_price_without_vat
+    assert_equal 0.0,   @purchase_price_paid_2.delivery_price_without_vat
+    assert_equal 14.47, @purchase_price_paid_3.delivery_price_without_vat
 
     assert_nil @auction_ended.delivery_price_without_vat
     assert_nil @delivery_offer_request.delivery_price_without_vat
@@ -224,6 +246,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#delivery_price_with_vat' do
     assert_equal 0.0,   @bidder_picks_up.delivery_price_with_vat
     assert_equal 17.95, @delivery_ordered.delivery_price_with_vat
+    assert_equal 0.0,   @purchase_price_paid_2.delivery_price_with_vat
+    assert_equal 17.95, @purchase_price_paid_3.delivery_price_with_vat
 
     assert_nil @auction_ended.delivery_price_with_vat
     assert_nil @delivery_offer_request.delivery_price_with_vat
@@ -234,8 +258,10 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#delivery_vat_percent' do
-    assert_equal 24, @bidder_picks_up.delivery_vat_percent
-    assert_equal 24, @delivery_ordered.delivery_vat_percent
+    assert_equal 24.0, @bidder_picks_up.delivery_vat_percent
+    assert_equal 24.0, @delivery_ordered.delivery_vat_percent
+    assert_equal 24.0, @purchase_price_paid_2.delivery_vat_percent
+    assert_equal 24.0, @purchase_price_paid_3.delivery_vat_percent
 
     assert_nil @auction_ended.delivery_vat_percent
     assert_nil @delivery_offer_request.delivery_vat_percent
@@ -248,6 +274,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#delivery_vat_amount' do
     assert_equal 0.0,  @bidder_picks_up.delivery_vat_amount
     assert_equal 3.48, @delivery_ordered.delivery_vat_amount
+    assert_equal 0.0,  @purchase_price_paid_2.delivery_vat_amount
+    assert_equal 3.48, @purchase_price_paid_3.delivery_vat_amount
 
     assert_nil @auction_ended.delivery_vat_amount
     assert_nil @delivery_offer_request.delivery_vat_amount
@@ -258,14 +286,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#total_price_with_vat' do
-    assert_equal 210.8,  @bidder_picks_up.total_price_with_vat
-    assert_equal 129.55, @delivery_ordered.total_price_with_vat
-    assert_equal 806.0,  @auction_ended.total_price_with_vat
-    assert_equal 372.0,  @delivery_offer_request.total_price_with_vat
-    assert_equal 824.6,  @offer_accepted.total_price_with_vat
-    assert_equal 372.0,  @offer_automatically_accepted.total_price_with_vat
-    assert_equal 62.0,   @offer_declined.total_price_with_vat
-    assert_equal 372.0,  @purchase_price_paid.total_price_with_vat
+    assert_equal 210.8,       @bidder_picks_up.total_price_with_vat
+    assert_equal 129.55,      @delivery_ordered.total_price_with_vat
+    assert_equal 806.0,       @auction_ended.total_price_with_vat
+    assert_equal 372.0,       @delivery_offer_request.total_price_with_vat
+    assert_equal 824.6,       @offer_accepted.total_price_with_vat
+    assert_equal 372.0,       @offer_automatically_accepted.total_price_with_vat
+    assert_equal 62.0,        @offer_declined.total_price_with_vat
+    assert_equal 372.0,       @purchase_price_paid.total_price_with_vat
+    assert_equal 248.0,       @purchase_price_paid_2.total_price_with_vat
+    assert_equal 92.35.to_d,  @purchase_price_paid_3.total_price_with_vat
   end
 
   test '#auction_id' do
@@ -277,6 +307,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '270265', @offer_automatically_accepted.auction_id
     assert_equal '277687', @offer_declined.auction_id
     assert_equal '270265', @purchase_price_paid.auction_id
+    assert_equal '287912', @purchase_price_paid_2.auction_id
+    assert_equal '285703', @purchase_price_paid_3.auction_id
   end
 
   test '#auction_title' do
@@ -303,6 +335,12 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
     title = '20.03.-25.03. Auton keinunostin, 1500 kg, UUSI, Lahti'
     assert_equal title, @purchase_price_paid.auction_title
+
+    title = '17.04.-23.04. Tunkkisetti. 20-30 tonnia, UUSIA, Lahti'
+    assert_equal title, @purchase_price_paid_2.auction_title
+
+    title = '24.04.-26.04. KAPPA reppu + KAPPA treenikassi + KAPPA sukat, UUSIA, Lahti'
+    assert_equal title, @purchase_price_paid_3.auction_title
   end
 
   test '#auction_closing_date' do
@@ -314,6 +352,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal "2016-03-25 20:20".to_time, @offer_automatically_accepted.auction_closing_date
     assert_equal "2016-03-25 19:40".to_time, @offer_declined.auction_closing_date
     assert_equal "2016-03-25 20:20".to_time, @purchase_price_paid.auction_closing_date
+    assert_equal "2016-04-23 19:40".to_time, @purchase_price_paid_2.auction_closing_date
+    assert_equal "2016-04-26 19:46".to_time, @purchase_price_paid_3.auction_closing_date
   end
 
   test '#auction_price_without_vat' do
@@ -325,17 +365,21 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 300, @offer_automatically_accepted.auction_price_without_vat
     assert_equal 50,  @offer_declined.auction_price_without_vat
     assert_equal 300, @purchase_price_paid.auction_price_without_vat
+    assert_equal 200, @purchase_price_paid_2.auction_price_without_vat
+    assert_equal 60,  @purchase_price_paid_3.auction_price_without_vat
   end
 
   test '#auction_price_with_vat' do
-    assert_equal 806.0, @auction_ended.auction_price_with_vat
-    assert_equal 210.8, @bidder_picks_up.auction_price_with_vat
-    assert_equal 372.0, @delivery_offer_request.auction_price_with_vat
-    assert_equal 111.6, @delivery_ordered.auction_price_with_vat
-    assert_equal 824.6, @offer_accepted.auction_price_with_vat
-    assert_equal 372.0, @offer_automatically_accepted.auction_price_with_vat
-    assert_equal 62.0,  @offer_declined.auction_price_with_vat
-    assert_equal 372.0, @purchase_price_paid.auction_price_with_vat
+    assert_equal 806.0,     @auction_ended.auction_price_with_vat
+    assert_equal 210.8,     @bidder_picks_up.auction_price_with_vat
+    assert_equal 372.0,     @delivery_offer_request.auction_price_with_vat
+    assert_equal 111.6,     @delivery_ordered.auction_price_with_vat
+    assert_equal 824.6,     @offer_accepted.auction_price_with_vat
+    assert_equal 372.0,     @offer_automatically_accepted.auction_price_with_vat
+    assert_equal 62.0,      @offer_declined.auction_price_with_vat
+    assert_equal 372.0,     @purchase_price_paid.auction_price_with_vat
+    assert_equal 248.0,     @purchase_price_paid_2.auction_price_with_vat
+    assert_equal 74.4.to_d, @purchase_price_paid_3.auction_price_with_vat
   end
 
   test '#auction_vat_percent' do
@@ -347,6 +391,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 24, @offer_automatically_accepted.auction_vat_percent
     assert_equal 24, @offer_declined.auction_vat_percent
     assert_equal 24, @purchase_price_paid.auction_vat_percent
+    assert_equal 24, @purchase_price_paid_2.auction_vat_percent
+    assert_equal 24, @purchase_price_paid_3.auction_vat_percent
   end
 
   test '#auction_vat_amount' do
@@ -358,6 +404,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 72.0,  @offer_automatically_accepted.auction_vat_amount
     assert_equal 12.0,  @offer_declined.auction_vat_amount
     assert_equal 72.0,  @purchase_price_paid.auction_vat_amount
+    assert_equal 48.0,  @purchase_price_paid_2.auction_vat_amount
+    assert_equal 14.4,  @purchase_price_paid_3.auction_vat_amount
   end
 
   test '#find_customer' do
@@ -365,13 +413,22 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal customers(:huutokauppa_customer_2), @offer_automatically_accepted.find_customer
     assert_equal customers(:huutokauppa_customer_2), @purchase_price_paid.find_customer
 
+    assert_nil @purchase_price_paid_2.find_customer
+    assert_nil @purchase_price_paid_3.find_customer
+
     @emails_without_customer_info.each do |email|
       assert_nil email.find_customer
     end
   end
 
   test '#create_customer' do
-    [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
+    [
+      @offer_accepted,
+      @offer_automatically_accepted,
+      @purchase_price_paid,
+      @purchase_price_paid_2,
+      @purchase_price_paid_3,
+    ].each do |email|
       Customer.delete_all
 
       assert_difference 'Customer.count' do
@@ -405,10 +462,18 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal sales_order_drafts(:huutokauppa_270265), @offer_automatically_accepted.find_order
     assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_order
     assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_order
+    assert_equal sales_order_drafts(:huutokauppa_287912), @purchase_price_paid_2.find_order
+    assert_equal sales_order_drafts(:huutokauppa_285703), @purchase_price_paid_3.find_order
   end
 
   test '#update_order_customer_info' do
-    [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
+    [
+      @offer_accepted,
+      @offer_automatically_accepted,
+      @purchase_price_paid,
+      @purchase_price_paid_2,
+      @purchase_price_paid_3,
+    ].each do |email|
       assert email.update_order_customer_info
 
       assert_equal email.customer_address,  email.find_order.osoite
@@ -451,6 +516,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_automatically_accepted,
       @offer_declined,
       @purchase_price_paid,
+      @purchase_price_paid_2,
+      @purchase_price_paid_3,
     ].each do |email|
       assert email.update_order_product_info
 
@@ -473,7 +540,13 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
 
     LegacyMethods.stub :pupesoft_function, sales_order_creation do
-      [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
+      [
+        @offer_accepted,
+        @offer_automatically_accepted,
+        @purchase_price_paid,
+        @purchase_price_paid_2,
+        @purchase_price_paid_3,
+      ].each do |email|
         assert_difference 'SalesOrder::Draft.count' do
           email.create_sales_order
         end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -286,16 +286,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#total_price_with_vat' do
-    assert_equal 210.8,       @bidder_picks_up.total_price_with_vat
-    assert_equal 129.55,      @delivery_ordered.total_price_with_vat
-    assert_equal 806.0,       @auction_ended.total_price_with_vat
-    assert_equal 372.0,       @delivery_offer_request.total_price_with_vat
-    assert_equal 824.6,       @offer_accepted.total_price_with_vat
-    assert_equal 372.0,       @offer_automatically_accepted.total_price_with_vat
-    assert_equal 62.0,        @offer_declined.total_price_with_vat
-    assert_equal 372.0,       @purchase_price_paid.total_price_with_vat
-    assert_equal 248.0,       @purchase_price_paid_2.total_price_with_vat
-    assert_equal 92.35.to_d,  @purchase_price_paid_3.total_price_with_vat
+    assert_equal 210.8,      @bidder_picks_up.total_price_with_vat
+    assert_equal 129.55,     @delivery_ordered.total_price_with_vat
+    assert_equal 806.0,      @auction_ended.total_price_with_vat
+    assert_equal 372.0,      @delivery_offer_request.total_price_with_vat
+    assert_equal 824.6,      @offer_accepted.total_price_with_vat
+    assert_equal 372.0,      @offer_automatically_accepted.total_price_with_vat
+    assert_equal 62.0,       @offer_declined.total_price_with_vat
+    assert_equal 372.0,      @purchase_price_paid.total_price_with_vat
+    assert_equal 248.0,      @purchase_price_paid_2.total_price_with_vat
+    assert_equal 92.35.to_d, @purchase_price_paid_3.total_price_with_vat
   end
 
   test '#auction_id' do

--- a/test/classes/stock_availablity_test.rb
+++ b/test/classes/stock_availablity_test.rb
@@ -11,6 +11,9 @@ class StockAvailabilityTest < ActiveSupport::TestCase
   )
 
   setup do
+    # Tests assume that hammer is the first product so huutokauppa_delivery_93 has to be deleted
+    products(:huutokauppa_delivery_93).delete
+
     @company = companies :acme
     @sales_order = sales_order_orders :so_one
     @purchase_order = purchase_order_orders :po_one

--- a/test/classes/stock_listing_csv_test.rb
+++ b/test/classes/stock_listing_csv_test.rb
@@ -11,6 +11,9 @@ class StockListingCsvTest < ActiveSupport::TestCase
   )
 
   setup do
+    # Tests assume that hammer is the first product so huutokauppa_delivery_93 has to be deleted
+    products(:huutokauppa_delivery_93).delete
+
     @company = companies :acme
     @purchase_order = purchase_order_orders :po_one
   end

--- a/test/fixtures/delivery_methods.yml
+++ b/test/fixtures/delivery_methods.yml
@@ -24,3 +24,9 @@ kiitolinja:
   tulostustapa: H
   <<: *DEFAULTS
 
+nouto:
+  selite: Nouto
+  tulostustapa: E
+  rahtikirja: rahtikirja_tyhja.inc
+  nouto: o
+  <<: *DEFAULTS

--- a/test/fixtures/delivery_methods.yml
+++ b/test/fixtures/delivery_methods.yml
@@ -24,6 +24,13 @@ kiitolinja:
   tulostustapa: H
   <<: *DEFAULTS
 
+itella_economy_16:
+  selite: Itella Economy 16
+  tulostustapa: H
+  rahtikirja: rahtikirja_unifaun_uo_siirto.inc
+  rahdinkuljettaja: IT16
+  <<: *DEFAULTS
+
 nouto:
   selite: Nouto
   tulostustapa: E

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -56,3 +56,11 @@ freight:
   nimitys: Rahti
   status: A
   <<: *DEFAULTS
+
+huutokauppa_delivery_93:
+  yhtio: acme
+  tuoteno: 93
+  nimitys: Posti-pakkaus- ja käsittelykulut7-10 kg
+  myyntihinta: 14.475806
+  status: A
+  <<: *DEFAULTS

--- a/test/fixtures/sales_order/drafts.yml
+++ b/test/fixtures/sales_order/drafts.yml
@@ -28,7 +28,7 @@ not_finished_order:
   terms_of_payment: hundred_days_net
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912].each do |auction_id| %>
 huutokauppa_<%= auction_id %>:
   yhtio: acme
   viesti: <%= auction_id %>

--- a/test/fixtures/sales_order/orders.yml
+++ b/test/fixtures/sales_order/orders.yml
@@ -25,6 +25,7 @@ DEFAULTS: &DEFAULTS
 so_one:
   yhtio: acme
   tila: L
+  toimitustapa: Nouto
   <<: *DEFAULTS
 
 

--- a/test/fixtures/sales_order/rows.yml
+++ b/test/fixtures/sales_order/rows.yml
@@ -13,7 +13,7 @@ so_row_one:
   tyyppi: L
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912].each do |auction_id| %>
 huutokauppa_<%= auction_id %>_row_1:
   order: huutokauppa_<%= auction_id %>
   tuoteno: hammer123

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -23,6 +23,19 @@ bob:
   luontiaika: <%= Time.now %>
   muutospvm: <%= Time.now %>
 
+admin:
+  yhtio: acme
+  kuka: admin
+  nimi: Admin Testi
+  salasana: <%= Digest::MD5.hexdigest('hevonen123') %>
+  session: PVHOINABDXGRFXVKMQHOETGJY
+  api_key: a2f7d8c21006cf11efba37d81e9f5711
+  muuttaja: admin
+  laatija: admin
+  lastlogin: <%= Time.now %>
+  luontiaika: <%= Time.now %>
+  muutospvm: <%= Time.now %>
+
 max:
   yhtio: esto
   kuka: max

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -115,4 +115,22 @@ class HuutokauppaJobTest < ActiveJob::TestCase
 
     assert_equal delivery_methods(:nouto), order.delivery_method
   end
+
+  test 'order delivery info is updated and delivery method set when type is delivery ordered' do
+    incoming_mail = incoming_mails(:three)
+
+    draft = sales_order_drafts(:huutokauppa_274472)
+    draft.tila = 'L'
+    draft.save(validate: false)
+
+    incoming_mail.raw_source = huutokauppa_email(:delivery_ordered_1)
+    incoming_mail.save!
+
+    HuutokauppaJob.perform_now(id: incoming_mail.id)
+
+    order = SalesOrder::Order.find_by!(viesti: 274_472)
+
+    assert_equal 'Test-testi testit Testites',         order.toim_nimi
+    assert_equal delivery_methods(:itella_economy_16), order.delivery_method
+  end
 end

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -45,6 +45,9 @@ class HuutokauppaJobTest < ActiveJob::TestCase
 
     assert_equal 'Test-testi Testite', sales_order.nimi
     assert_equal 300, sales_order.rows.first.rivihinta
+
+    assert_equal 'ok', incoming_mail.reload.status
+    assert_nil incoming_mail.reload.status_message
   end
 
   test 'customer is created and customer and product info are updated correctly to order when customer is not found' do
@@ -75,6 +78,9 @@ class HuutokauppaJobTest < ActiveJob::TestCase
 
     assert_equal 'Test-testi Testite', sales_order.nimi
     assert_equal 300, sales_order.rows.first.rivihinta
+
+    assert_equal 'ok', incoming_mail.reload.status
+    assert_nil incoming_mail.reload.status_message
   end
 
   test 'error is logged if exception is thrown' do
@@ -114,6 +120,9 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     order = SalesOrder::Order.find_by!(viesti: 270_265)
 
     assert_equal delivery_methods(:nouto), order.delivery_method
+
+    assert_equal 'ok', incoming_mail.reload.status
+    assert_nil incoming_mail.reload.status_message
   end
 
   test 'order delivery info is updated and delivery method set when type is delivery ordered' do
@@ -132,5 +141,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
 
     assert_equal 'Test-testi testit Testites',         order.toim_nimi
     assert_equal delivery_methods(:itella_economy_16), order.delivery_method
+
+    assert_equal 'ok', incoming_mail.reload.status
+    assert_nil incoming_mail.reload.status_message
   end
 end

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -4,6 +4,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
   fixtures %w(
     incoming_mails
     mail_servers
+    sales_order/drafts
+    sales_order/rows
   )
 
   test 'job is enqueued correctly' do
@@ -12,5 +14,63 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     HuutokauppaJob.perform_later(id: incoming_mails(:three).id)
 
     assert_enqueued_jobs 1
+  end
+
+  test 'customer and product info are updated correctly to order when customer is found' do
+    incoming_mail = incoming_mails(:three)
+
+    incoming_mail.raw_source = huutokauppa_email(:offer_accepted_1)
+    incoming_mail.save!
+
+    assert_no_difference 'Customer.count' do
+      HuutokauppaJob.perform_now(id: incoming_mail.id)
+    end
+
+    sales_order = SalesOrder::Draft.find_by!(viesti: 277_075)
+
+    assert_equal 'Testi Testit Testitestit', sales_order.nimi
+    assert_equal 665, sales_order.rows.first.rivihinta
+
+    incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
+    incoming_mail.save!
+
+    assert_no_difference 'Customer.count' do
+      HuutokauppaJob.perform_now(id: incoming_mail.id)
+    end
+
+    sales_order = SalesOrder::Draft.find_by!(viesti: 270_265)
+
+    assert_equal 'Test-testi Testite', sales_order.nimi
+    assert_equal 300, sales_order.rows.first.rivihinta
+  end
+
+  test 'customer is created and customer and product info are updated correctly to order when customer is not found' do
+    Customer.delete_all
+
+    incoming_mail = incoming_mails(:three)
+
+    incoming_mail.raw_source = huutokauppa_email(:offer_accepted_1)
+    incoming_mail.save!
+
+    assert_difference 'Customer.count' do
+      HuutokauppaJob.perform_now(id: incoming_mail.id)
+    end
+
+    sales_order = SalesOrder::Draft.find_by!(viesti: 277_075)
+
+    assert_equal 'Testi Testit Testitestit', sales_order.nimi
+    assert_equal 665, sales_order.rows.first.rivihinta
+
+    incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
+    incoming_mail.save!
+
+    assert_difference 'Customer.count' do
+      HuutokauppaJob.perform_now(id: incoming_mail.id)
+    end
+
+    sales_order = SalesOrder::Draft.find_by!(viesti: 270_265)
+
+    assert_equal 'Test-testi Testite', sales_order.nimi
+    assert_equal 300, sales_order.rows.first.rivihinta
   end
 end

--- a/test/models/delivery_method_test.rb
+++ b/test/models/delivery_method_test.rb
@@ -4,19 +4,23 @@ class DeliveryMethodTest < ActiveSupport::TestCase
   fixtures %w(
     customers
     delivery_methods
+    sales_order/orders
   )
 
   setup do
     @kaukokiito = delivery_methods(:kaukokiito)
     @kiitolinja = delivery_methods(:kiitolinja)
+    @nouto      = delivery_methods(:nouto)
   end
 
   test 'fixtures are valid' do
     assert @kaukokiito.valid?
     assert @kiitolinja.valid?
+    assert @nouto.valid?
   end
 
   test 'relations' do
     assert @kaukokiito.customers.count > 0
+    assert @nouto.sales_orders.count > 0
   end
 end

--- a/test/models/sales_order/order_test.rb
+++ b/test/models/sales_order/order_test.rb
@@ -2,9 +2,10 @@ require 'test_helper'
 
 class SalesOrder::OrderTest < ActiveSupport::TestCase
   fixtures %w(
+    delivery_methods
+    head/voucher_rows
     sales_order/orders
     sales_order/rows
-    head/voucher_rows
   )
 
   setup do
@@ -20,5 +21,6 @@ class SalesOrder::OrderTest < ActiveSupport::TestCase
     assert @order.accounting_rows.count > 0
     assert @order.rows.count > 0
     assert_equal "L", @order.rows.first.tyyppi
+    assert_equal delivery_methods(:nouto), @order.delivery_method
   end
 end


### PR DESCRIPTION
- Process `offer_accepted` and `offer_automatically_accepted` emails in `HuutokauppaJob`
- Process `purchase_price_paid` emails in `HuutokauppaJob`
- Process `delivery_ordered` emails in `HuutokauppaJob`
- Log exceptions in `HuutokauppaJob`
- Use Pupesoft function `lisaa_rivi` in `add_delivery_row`
- Add correct delivery row for order according to new logic