### PR TITLE
Huutokauppa fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'axlsx_rails'
 gem 'pdfkit'
 gem 'lightbox2-rails'
 gem 'wicked_pdf'
+gem 'whenever', require: false
 
 group :assets do
   gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       rails (>= 3.1)
     bcrypt (3.1.11)
     builder (3.2.2)
+    chronic (0.10.2)
     cocoon (1.2.9)
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -257,6 +258,8 @@ GEM
     unicode_utils (1.4.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     wicked_pdf (1.0.6)
     ya2yaml (0.31)
 
@@ -293,6 +296,7 @@ DEPENDENCIES
   therubyracer
   turbolinks
   uglifier
+  whenever
   wicked_pdf
 
 BUNDLED WITH

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -219,6 +219,7 @@ class HuutokauppaMail
 
     find_draft.update!(
       nimi: customer_name,
+      nimitark: '',
       osoite: customer_address,
       postino: customer_postcode,
       postitp: customer_city,

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -166,7 +166,7 @@ class HuutokauppaMail
       osoite: customer_address,
       postino: customer_postcode,
       postitp: customer_city,
-      ytunnus: auction_id,
+      ytunnus: company_id || auction_id,
     )
 
     @messages << "Customer #{customer.id} created"
@@ -224,6 +224,7 @@ class HuutokauppaMail
       postitp: customer_city,
       email: customer_email,
       puh: customer_phone,
+      ytunnus: company_id || auction_id,
       toim_nimi: '',
       toim_nimitark: '',
       toim_osoite: '',

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -169,7 +169,7 @@ class HuutokauppaMail
       ytunnus: company_id || auction_id,
     )
 
-    @messages << "Asiakas #{customer.id} luotu."
+    @messages << "Asiakas #{customer_message_info(customer)} luotu."
 
     customer
   end
@@ -185,14 +185,14 @@ class HuutokauppaMail
       postitp: customer_city,
     )
 
-    @messages << "Asiakas #{find_customer.id} päivitetty."
+    @messages << "Asiakas #{customer_message_info(find_customer)} päivitetty."
 
     true
   end
 
   def update_or_create_customer
     if find_customer
-      @messages << "Asiakas #{find_customer.id} löytyi, joten päivitetään kyseisen asiakkaan tiedot."
+      @messages << "Asiakas #{customer_message_info(find_customer)} löytyi, joten päivitetään kyseisen asiakkaan tiedot."
 
       update_customer
 
@@ -245,7 +245,7 @@ class HuutokauppaMail
       laskutus_maa: '',
     )
 
-    @messages << "Päivitettiin tilauksen #{find_draft.id} asiakastiedot."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} asiakastiedot."
 
     true
   end
@@ -262,7 +262,7 @@ class HuutokauppaMail
       toim_puh: delivery_phone,
     )
 
-    @messages << "Päivitettiin tilauksen #{find_order.id} toimitustiedot."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_order)} toimitustiedot."
 
     true
   end
@@ -285,7 +285,7 @@ class HuutokauppaMail
       LegacyMethods.pupesoft_function(:tuoteperheiden_hintojen_paivitys, parent_row_ids: { row.id => child_row_ids })
     end
 
-    @messages << "Päivitettiin tilauksen #{find_draft.id} rivin #{row.id} tuotetiedot."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} tuotetiedot."
 
     true
   end
@@ -309,13 +309,13 @@ class HuutokauppaMail
                      .order(:myyntihinta)
                      .first!
 
-    @messages << "Löydettiin tuote #{product.id} lisättäväksi toimitustuotteeksi."
+    @messages << "Löydettiin tuote #{product.tuoteno} lisättäväksi toimitustuotteeksi."
 
     response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_draft.id, product_id: product.id)
 
     row = find_draft.rows.find(response[:added_row])
 
-    @messages << "Lisättiin toimitusrivi #{row.id} tilaukselle #{find_draft.id}."
+    @messages << "Lisättiin toimitusrivi tilaukselle #{order_message_info(find_draft)}."
 
     row
   end
@@ -323,7 +323,7 @@ class HuutokauppaMail
   def update_delivery_method_to_nouto
     find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
 
-    @messages << "Päivitettiin tilauksen #{find_draft.id} toimitustavaksi Nouto."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} toimitustavaksi Nouto."
 
     true
   end
@@ -331,7 +331,7 @@ class HuutokauppaMail
   def update_delivery_method_to_itella_economy_16
     find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
 
-    @messages << "Päivitettiin tilauksen #{find_order.id} toimitustavaksi Itella Economy 16."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_order)} toimitustavaksi Itella Economy 16."
 
     true
   end
@@ -339,7 +339,7 @@ class HuutokauppaMail
   def mark_as_done
     response = find_draft.mark_as_done(create_preliminary_invoice: true)
 
-    @messages << "Merkittiin tilaus #{find_draft.id} valmiiksi."
+    @messages << "Merkittiin tilaus #{order_message_info(find_draft)} valmiiksi."
 
     response
   end
@@ -430,5 +430,13 @@ class HuutokauppaMail
       end
 
       info
+    end
+
+    def customer_message_info(customer)
+      "#{customer.nimi} (#{customer.email})"
+    end
+
+    def order_message_info(order)
+      "(Tilausnumero: #{order.id}, Huutokauppa: #{auction_id})"
     end
 end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -188,10 +188,14 @@ class HuutokauppaMail
 
       update_customer
 
-      return find_customer
+      customer = find_customer
+    else
+      customer = create_customer
     end
 
-    create_customer
+    find_draft.update!(customer: customer)
+
+    customer
   end
 
   def find_draft

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -37,6 +37,10 @@ class HuutokauppaMail
     customer_info[:company_name]
   end
 
+  def company_id
+    customer_info[:company_id]
+  end
+
   def customer_name
     customer_info[:name]
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -169,7 +169,7 @@ class HuutokauppaMail
       ytunnus: company_id || auction_id,
     )
 
-    @messages << "Customer #{customer.id} created"
+    @messages << "Asiakas #{customer.id} luotu."
 
     customer
   end
@@ -185,14 +185,14 @@ class HuutokauppaMail
       postitp: customer_city,
     )
 
-    @messages << "Customer #{find_customer.id} updated"
+    @messages << "Asiakas #{find_customer.id} päivitetty."
 
     true
   end
 
   def update_or_create_customer
     if find_customer
-      @messages << "Customer #{find_customer.id} was found, so updating existing customer info"
+      @messages << "Asiakas #{find_customer.id} löytyi, joten päivitetään kyseisen asiakkaan tiedot."
 
       update_customer
 
@@ -245,7 +245,7 @@ class HuutokauppaMail
       laskutus_maa: '',
     )
 
-    @messages << "Updated order #{find_draft.id} customer info"
+    @messages << "Päivitettiin tilauksen #{find_draft.id} asiakastiedot."
 
     true
   end
@@ -262,7 +262,7 @@ class HuutokauppaMail
       toim_puh: delivery_phone,
     )
 
-    @messages << "Updated order #{find_order.id} delivery_info"
+    @messages << "Päivitettiin tilauksen #{find_order.id} toimitustiedot."
 
     true
   end
@@ -285,7 +285,7 @@ class HuutokauppaMail
       LegacyMethods.pupesoft_function(:tuoteperheiden_hintojen_paivitys, parent_row_ids: { row.id => child_row_ids })
     end
 
-    @messages << "Updated order #{find_draft.id} row #{row.id} product info"
+    @messages << "Päivitettiin tilauksen #{find_draft.id} rivin #{row.id} tuotetiedot."
 
     true
   end
@@ -309,13 +309,13 @@ class HuutokauppaMail
                      .order(:myyntihinta)
                      .first!
 
-    @messages << "Found product #{product.id} to add as delivery product"
+    @messages << "Löydettiin tuote #{product.id} lisättäväksi toimitustuotteeksi."
 
     response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_draft.id, product_id: product.id)
 
     row = find_draft.rows.find(response[:added_row])
 
-    @messages << "Added delivery row #{row.id} for order #{find_draft.id}"
+    @messages << "Lisättiin toimitusrivi #{row.id} tilaukselle #{find_draft.id}."
 
     row
   end
@@ -323,7 +323,7 @@ class HuutokauppaMail
   def update_delivery_method_to_nouto
     find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
 
-    @messages << "Updated order #{find_draft.id} delivery method to Nouto"
+    @messages << "Päivitettiin tilauksen #{find_draft.id} toimitustavaksi Nouto."
 
     true
   end
@@ -331,7 +331,7 @@ class HuutokauppaMail
   def update_delivery_method_to_itella_economy_16
     find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
 
-    @messages << "Updated order #{find_order.id} delivery method to Itella Economy 16"
+    @messages << "Päivitettiin tilauksen #{find_order.id} toimitustavaksi Itella Economy 16."
 
     true
   end
@@ -339,7 +339,7 @@ class HuutokauppaMail
   def mark_as_done
     response = find_draft.mark_as_done(create_preliminary_invoice: true)
 
-    @messages << "Marked order #{find_draft.id} as done"
+    @messages << "Merkittiin tilaus #{find_draft.id} valmiiksi."
 
     response
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -270,6 +270,11 @@ class HuutokauppaMail
       rivihinta_valuutassa: auction_price_without_vat,
     )
 
+    if row.perheid != 0
+      child_row_ids = find_draft.rows.where.not(tunnus: row.tunnus).pluck(:tunnus)
+      LegacyMethods.pupesoft_function(:tuoteperheiden_hintojen_paivitys, parent_row_ids: { row.id => child_row_ids })
+    end
+
     @messages << "Updated order #{find_draft.id} row #{row.id} product info"
 
     true

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -309,6 +309,8 @@ class HuutokauppaMail
                      .order(:myyntihinta)
                      .first!
 
+    @messages << "Found product #{product.id} to add as delivery product"
+
     response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_draft.id, product_id: product.id)
 
     row = find_draft.rows.find(response[:added_row])

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -339,7 +339,7 @@ class HuutokauppaMail
   def mark_as_done
     response = find_draft.mark_as_done(create_preliminary_invoice: true)
 
-    @messages << "Marked order #{find_order.id} as done"
+    @messages << "Marked order #{find_draft.id} as done"
 
     response
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -33,6 +33,10 @@ class HuutokauppaMail
     end
   end
 
+  def company_name
+    customer_info[:company_name]
+  end
+
   def customer_name
     customer_info[:name]
   end

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -16,6 +16,8 @@ class HuutokauppaJob < ActiveJob::Base
                 mark_order_as_done_and_set_delivery_method
               when :delivery_ordered
                 update_order_delivery_info_and_delivery_method
+              else
+                true
               end
 
     return false unless success
@@ -23,6 +25,7 @@ class HuutokauppaJob < ActiveJob::Base
     @incoming_mail.update!(
       processed_at: Time.now,
       status: :ok,
+      status_message: @huutokauppa_mail.messages.join("\n"),
     )
   end
 

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -61,10 +61,12 @@ class HuutokauppaJob < ActiveJob::Base
     end
 
     def log_error(exception)
+      @huutokauppa_mail.messages << exception.message
+
       @incoming_mail.update!(
         processed_at: Time.now,
         status: :error,
-        status_message: exception.message,
+        status_message: @huutokauppa_mail.messages.join("\n"),
       )
     end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -11,6 +11,7 @@ class Customer < BaseModel
   has_many :products, through: :prices
   has_many :sales_details, foreign_key: :liitostunnus, class_name: 'SalesOrder::Detail'
   has_many :transports, as: :transportable
+  has_many :heads, foreign_key: :liitostunnus
 
   validates :asiakasnro, uniqueness: { scope: :yhtio }, allow_blank: true
   validates :maa, inclusion: { in: proc { Country.pluck(:koodi) } }

--- a/app/models/head.rb
+++ b/app/models/head.rb
@@ -7,6 +7,8 @@ class Head < BaseModel
 
   belongs_to :terms_of_payment, foreign_key: :maksuehto
   belongs_to :delivery_method, foreign_key: :toimitustapa, primary_key: :selite
+  belongs_to :customer, foreign_key: :liitostunnus
+
   has_many :accounting_rows, class_name: 'Head::VoucherRow', foreign_key: :ltunnus
   has_one :detail, foreign_key: :otunnus, class_name: 'HeadDetail'
 

--- a/app/views/administration/incoming_mails/index.html.erb
+++ b/app/views/administration/incoming_mails/index.html.erb
@@ -38,7 +38,15 @@
           <td><%= incoming_mail.mail_server %></td>
           <td><%= l(incoming_mail.processed_at) if incoming_mail.processed_at %></td>
           <td><%= incoming_mail.status %></td>
-          <td><%= incoming_mail.status_message %></td>
+          <td>
+            <% if incoming_mail.status_message %>
+              <ul>
+                <% incoming_mail.status_message.split("\n").each do |message| %>
+                  <li><%= message %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every 5.minutes do
+  runner 'IncomingMailJob.perform_later'
+end

--- a/db/migrate/20160504081622_change_incoming_mail_status_message_to_text.rb
+++ b/db/migrate/20160504081622_change_incoming_mail_status_message_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeIncomingMailStatusMessageToText < ActiveRecord::Migration
+  def change
+    change_column :incoming_mails, :status_message, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160427135635) do
+ActiveRecord::Schema.define(version: 20160504081622) do
 
   create_table "abc_aputaulu", primary_key: "tunnus", force: :cascade do |t|
     t.string   "yhtio",              limit: 5,                            default: "",  null: false
@@ -737,7 +737,7 @@ ActiveRecord::Schema.define(version: 20160427135635) do
     t.integer  "mail_server_id", limit: 4
     t.datetime "processed_at"
     t.integer  "status",         limit: 4
-    t.string   "status_message", limit: 255
+    t.text     "status_message", limit: 65535
     t.datetime "created_at",                        null: false
     t.datetime "updated_at",                        null: false
   end

--- a/test/assets/huutokauppa_emails/offer_accepted_2
+++ b/test/assets/huutokauppa_emails/offer_accepted_2
@@ -1,0 +1,68 @@
+Return-path: <bounces@automated.huutokaupat.com>
+Envelope-to: testite@testi.te
+Delivery-date: Sun, 01 May 2016 20:42:19 +0300
+Received: from filter1.hostingservice.fi ([31.217.192.66]:42381)
+    by cloud13.hostingpalvelu.fi with esmtps (TLSv1.2:ECDHE-RSA-AES256-GCM-SHA384:256)
+    (Exim 4.86_1)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1awvNp-0016tZ-BH; Sun, 01 May 2016 20:42:17 +0300
+Received: from server.huutokaupat.com ([83.150.76.4])
+    by filter1.hostingservice.fi with esmtp (Exim 4.85)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1awvNl-0000Tw-TY; Sun, 01 May 2016 20:42:14 +0300
+Received: from localhost (unknown [10.10.10.128])
+    by server.huutokaupat.com (Postfix) with ESMTP id 15A1B2007F1;
+    Sun,  1 May 2016 20:42:13 +0300 (EEST)
+From: testite@testi.te
+Subject: =?utf-8?Q?Tarjous=20hyv=C3=A4ksytty=20Huutokaupat.com=20?=
+ =?utf-8?Q?nettihuutokauppa:=20kohde=20#293363?=
+Date: Sun, 01 May 2016 20:42:13 +0300
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+MIME-Version: 1.0
+X-Filter-ID: s0sct1PQhAABKnZB5plbIeAyHwHIceqjIqYzluv0NUpuO2tWUqBCEbdShNj29n29hTQlI8BJQNwf
+ dZmIYTr6GnVEJQAYV9ff1+lJ+Sf2nQ3k+GDP+f6xF7XLnlq3j2ne/5FdbgtqnqT56S7k+tyLwZHf
+ WZYD82R/uX1kWNJz4wES3dsoT4fYpUWtq2l6tT6ampYbIWehzfMhBX2xrya8NiYD1ptUVn6ByrDO
+ Wen4bPcvcplYN5zMlHdXzOu7gRr7JZBJUDyXddX3lRgqX8VJ+gZ2Oot2XYq2kcVIzFMQkte6tPHt
+ LyzZCWuI1lWShN2ZN4vrymjsdGFkvzyl2w+OSKdjrowL4Lbb9iPXgXZMS2D3Y80OmAux3oN13+zt
+ UznelVU9QgLK/0NCrwKOqAJ5j/lhx6pU3jITEHpzR9O3Rjl+YkebNpvJ/YTk5oHVPSirznsNVgZN
+ KbobVf+Qae5nZG9+e53NefSh2/8kCwc1rDLpUvOxYUnyxbbUASXHNpr+VOO/b7lTup0CCuVmNqF4
+ 0Z4k2agBwYlgSHRHnifdLq1I9kstLHf/oFOkvpReZPzICaahY2BPC5luEBRZsU4u+BLrFBaNd6fA
+ g4sYWjlUC8976jAug3OpQr0UDRHCm0TmXK96n2SyFp5YmSLx3rM8b0y/GiBOhBixOC4/4AGJ2W+W
+ Z3A8Pu2r1COhrvRAzWOdnEDOOfnFvfsNckTY9armWyFitXn5B2UkoUPDaz4SqRzAQhs3PFMfWHR3
+ Vzbplcfla2eq3FgLgDwymrmz6kSIHgxxUZPc61zvoPUs+NjgJXlANsOQ3evmwHLth6gebCxAgxD8
+ /eA9tGWJAPv75lJC/jEvuGslKTrRIXcXpFg5ivY=
+X-Report-Abuse-To: spam@filter1.hostingservice.fi
+X-SpamExperts-Class: whitelisted
+X-SpamExperts-Evidence: sender
+X-Recommended-Action: accept
+
+<p>=0A    Olette hyv=C3=A4ksyneet tarjouksen seuraavasta kohteesta:=0A</=
+p>=0A=0A<p>=0A    Kohde #293363<br/>=0A    Otsikkokentt=C3=A4: 26.04.-01=
+.05. BOBCAT 320 kaivinkone, Lahti<br/>=0A    P=C3=A4=C3=A4ttymisaika: Su=
+nnuntai 01.05.2016 klo 20:25<br/>=0A    Huudettu: 8=C2=A0600 EUR<br/>=0A=
+    Alv-osuus: 2=C2=A0064 EUR<br/>=0A    Summa: 10=C2=A0664 EUR, ALV 24=
+ %=0A</p>=0A=0A<p>=0A    Ostajan yhteystiedot:<br/>=0A            Yritys=
+:<br/>=0A        Testites Oy<br/>=0A        FI01234567<br/>=0A        Te=
+sti Testi=C3=A4<br/>=0A    testi.testit@testit.te<br/>=0A            Puh=
+elin: +123 45 6789012<br/>=0A        Osoite:<br/>=0A    Testites 52<br/>=
+=0A    12345 Test=C3=A4tes<br/>=0A    Suomi=0A</p>=0A=0A<p>=0A    Myyj=
+=C3=A4n/toimeksisaaneen yhteystiedot:<br/>=0A    Testi Testitest<br />=
+=0AY-tunnus: 1234567-8<br />=0ATest Testites<br />=0Atest.testites@testi=
+.te<br />=0A+123 45 6789012<br />=0A<br />=0ARahti tilaukset<br />=0Ates=
+tit@testi.te<br />=0A<br />=0A<br />=0AIlmoittajan viite: 3191-12<br />=
+=0A<br/>=0A    <br/>=0A    Maksutapa: Verkkopankkimaksu. Pankit: Nordea,=
+ Danske Bank, Osuuspankki, S-pankki, Aktia, Handelsbanken, =C3=85landsba=
+nken, Pop-pankki, S=C3=A4=C3=A4st=C3=B6pankki, Oma S=C3=A4=C3=A4st=C3=B6=
+pankki<br/>=0A    <br/>=0A    Huutokaupan tilana n=C3=A4kyy ilmoituksess=
+a: P=C3=A4=C3=A4ttynyt =E2=80=93 tarjous hyv=C3=A4ksytty.<br/>=0A    <br=
+/>=0A    Kohteen ostajalla on kaksi arkip=C3=A4iv=C3=A4=C3=A4 aikaa suor=
+ittaa kauppahinta Huutokaupat.com palvelua yll=C3=A4pit=C3=A4v=C3=A4n Me=
+zzoforte Oy:n asiakastilille.  Saatte meilt=C3=A4 s=C3=A4hk=C3=B6postill=
+a vahvistuksen toteutuneesta kauppasummasta.<br/>=0A    <br/>=0A    Maks=
+usuorituksen j=C3=A4lkeen huutokaupan tilana n=C3=A4kyy ilmoituksessa: M=
+yyty.<br/>=0A    <br/>=0A    Myyntikohde n=C3=A4kyy myynnin toteuduttua=
+ sivuilla 7 p=C3=A4iv=C3=A4=C3=A4 ja poistuu t=C3=A4m=C3=A4n j=C3=A4lkee=
+n sivuilta automaattisesti.=0A</p>=0A=0A<p>=0A    Yst=C3=A4v=C3=A4llisin=
+ terveisin,<br/>=0AHuutokaupat.com=0A=0A</p>=0A

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -108,6 +108,22 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @purchase_price_paid_3.company_name
   end
 
+  test '#company_id' do
+    assert_equal 'FI01234567', @offer_accepted_2.company_id
+
+    assert_nil @auction_ended.company_id
+    assert_nil @bidder_picks_up.company_id
+    assert_nil @delivery_offer_request.company_id
+    assert_nil @delivery_ordered.company_id
+    assert_nil @invalid_customer_info.company_id
+    assert_nil @offer_accepted.company_id
+    assert_nil @offer_automatically_accepted.company_id
+    assert_nil @offer_declined.company_id
+    assert_nil @purchase_price_paid.company_id
+    assert_nil @purchase_price_paid_2.company_id
+    assert_nil @purchase_price_paid_3.company_id
+  end
+
   test '#customer_name' do
     assert_equal 'Testi Testit Testitestit', @offer_accepted.customer_name
     assert_equal 'Testi Testiä',             @offer_accepted_2.customer_name

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -27,6 +27,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     @delivery_ordered             = HuutokauppaMail.new huutokauppa_email(:delivery_ordered_1)
     @invalid_customer_info        = HuutokauppaMail.new huutokauppa_email(:invalid_customer_info)
     @offer_accepted               = HuutokauppaMail.new huutokauppa_email(:offer_accepted_1)
+    @offer_accepted_2             = HuutokauppaMail.new huutokauppa_email(:offer_accepted_2)
     @offer_automatically_accepted = HuutokauppaMail.new huutokauppa_email(:offer_automatically_accepted_1)
     @offer_declined               = HuutokauppaMail.new huutokauppa_email(:offer_declined_1)
     @purchase_price_paid          = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_1)
@@ -45,6 +46,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @auction_ended,
       @bidder_picks_up,
       @offer_accepted,
+      @offer_accepted_2,
       @offer_automatically_accepted,
       @offer_declined,
       @purchase_price_paid,
@@ -82,6 +84,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal :delivery_ordered,             @delivery_ordered.type
     assert_equal :offer_accepted,               @invalid_customer_info.type
     assert_equal :offer_accepted,               @offer_accepted.type
+    assert_equal :offer_accepted,               @offer_accepted_2.type
     assert_equal :offer_automatically_accepted, @offer_automatically_accepted.type
     assert_equal :offer_declined,               @offer_declined.type
     assert_equal :purchase_price_paid,          @purchase_price_paid.type
@@ -91,6 +94,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#customer_name' do
     assert_equal 'Testi Testit Testitestit', @offer_accepted.customer_name
+    assert_equal 'Testi Testiä',             @offer_accepted_2.customer_name
     assert_equal 'Test-testi Testite',       @offer_automatically_accepted.customer_name
     assert_equal 'Test-testi Testite',       @purchase_price_paid.customer_name
     assert_equal 'Test testit Testi',        @purchase_price_paid_2.customer_name
@@ -107,6 +111,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#customer_email' do
     assert_equal 'testit@testi.tes',          @offer_accepted.customer_email
+    assert_equal 'testi.testit@testit.te',    @offer_accepted_2.customer_email
     assert_equal 'te.testite@testi.tes',      @offer_automatically_accepted.customer_email
     assert_equal 'te.testite@testi.tes',      @purchase_price_paid.customer_email
     assert_equal 'test.testi@testitestit.fi', @purchase_price_paid_2.customer_email
@@ -119,6 +124,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#customer_phone' do
     assert_equal '+123 45 6789012', @offer_accepted.customer_phone
+    assert_equal '+123 45 6789012', @offer_accepted_2.customer_phone
     assert_equal '+123 45 6789012', @offer_automatically_accepted.customer_phone
     assert_equal '+123 45 6789012', @purchase_price_paid.customer_phone
     assert_equal '+123 45 6789012', @purchase_price_paid_2.customer_phone
@@ -131,6 +137,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#customer_address' do
     assert_equal 'testitestit 12',    @offer_accepted.customer_address
+    assert_equal 'Testites 52',       @offer_accepted_2.customer_address
     assert_equal 'Testitesti 123',    @offer_automatically_accepted.customer_address
     assert_equal 'Testitesti 123',    @purchase_price_paid.customer_address
     assert_equal 'Testitest 21',      @purchase_price_paid_2.customer_address
@@ -143,6 +150,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#customer_postcode' do
     assert_equal '12345', @offer_accepted.customer_postcode
+    assert_equal '12345', @offer_accepted_2.customer_postcode
     assert_equal '23456', @offer_automatically_accepted.customer_postcode
     assert_equal '12345', @purchase_price_paid.customer_postcode
     assert_equal '12345', @purchase_price_paid_2.customer_postcode
@@ -155,6 +163,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#customer_city' do
     assert_equal 'Testi',      @offer_accepted.customer_city
+    assert_equal 'Testätes',   @offer_accepted_2.customer_city
     assert_equal 'Testitesti', @offer_automatically_accepted.customer_city
     assert_equal 'Testitesti', @purchase_price_paid.customer_city
     assert_equal 'Testi',      @purchase_price_paid_2.customer_city
@@ -167,6 +176,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#customer_country' do
     assert_equal 'Suomi', @offer_accepted.customer_country
+    assert_equal 'Suomi', @offer_accepted_2.customer_country
     assert_equal 'Suomi', @offer_automatically_accepted.customer_country
     assert_equal 'Suomi', @purchase_price_paid.customer_country
     assert_equal 'Suomi', @purchase_price_paid_2.customer_country
@@ -240,6 +250,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @auction_ended.delivery_price_without_vat
     assert_nil @delivery_offer_request.delivery_price_without_vat
     assert_nil @offer_accepted.delivery_price_without_vat
+    assert_nil @offer_accepted_2.delivery_price_without_vat
     assert_nil @offer_automatically_accepted.delivery_price_without_vat
     assert_nil @offer_declined.delivery_price_without_vat
     assert_nil @purchase_price_paid.delivery_price_without_vat
@@ -254,6 +265,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @auction_ended.delivery_price_with_vat
     assert_nil @delivery_offer_request.delivery_price_with_vat
     assert_nil @offer_accepted.delivery_price_with_vat
+    assert_nil @offer_accepted_2.delivery_price_with_vat
     assert_nil @offer_automatically_accepted.delivery_price_with_vat
     assert_nil @offer_declined.delivery_price_with_vat
     assert_nil @purchase_price_paid.delivery_price_with_vat
@@ -268,6 +280,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @auction_ended.delivery_vat_percent
     assert_nil @delivery_offer_request.delivery_vat_percent
     assert_nil @offer_accepted.delivery_vat_percent
+    assert_nil @offer_accepted_2.delivery_vat_percent
     assert_nil @offer_automatically_accepted.delivery_vat_percent
     assert_nil @offer_declined.delivery_vat_percent
     assert_nil @purchase_price_paid.delivery_vat_percent
@@ -282,6 +295,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @auction_ended.delivery_vat_amount
     assert_nil @delivery_offer_request.delivery_vat_amount
     assert_nil @offer_accepted.delivery_vat_amount
+    assert_nil @offer_accepted_2.delivery_vat_amount
     assert_nil @offer_automatically_accepted.delivery_vat_amount
     assert_nil @offer_declined.delivery_vat_amount
     assert_nil @purchase_price_paid.delivery_vat_amount
@@ -293,6 +307,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 806.0,      @auction_ended.total_price_with_vat
     assert_equal 372.0,      @delivery_offer_request.total_price_with_vat
     assert_equal 824.6,      @offer_accepted.total_price_with_vat
+    assert_equal 10664.0,    @offer_accepted_2.total_price_with_vat
     assert_equal 372.0,      @offer_automatically_accepted.total_price_with_vat
     assert_equal 62.0,       @offer_declined.total_price_with_vat
     assert_equal 372.0,      @purchase_price_paid.total_price_with_vat
@@ -359,16 +374,17 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#auction_price_without_vat' do
-    assert_equal 650, @auction_ended.auction_price_without_vat
-    assert_equal 170, @bidder_picks_up.auction_price_without_vat
-    assert_equal 300, @delivery_offer_request.auction_price_without_vat
-    assert_equal 90,  @delivery_ordered.auction_price_without_vat
-    assert_equal 665, @offer_accepted.auction_price_without_vat
-    assert_equal 300, @offer_automatically_accepted.auction_price_without_vat
-    assert_equal 50,  @offer_declined.auction_price_without_vat
-    assert_equal 300, @purchase_price_paid.auction_price_without_vat
-    assert_equal 200, @purchase_price_paid_2.auction_price_without_vat
-    assert_equal 60,  @purchase_price_paid_3.auction_price_without_vat
+    assert_equal 650,  @auction_ended.auction_price_without_vat
+    assert_equal 170,  @bidder_picks_up.auction_price_without_vat
+    assert_equal 300,  @delivery_offer_request.auction_price_without_vat
+    assert_equal 90,   @delivery_ordered.auction_price_without_vat
+    assert_equal 665,  @offer_accepted.auction_price_without_vat
+    assert_equal 8600, @offer_accepted_2.auction_price_without_vat
+    assert_equal 300,  @offer_automatically_accepted.auction_price_without_vat
+    assert_equal 50,   @offer_declined.auction_price_without_vat
+    assert_equal 300,  @purchase_price_paid.auction_price_without_vat
+    assert_equal 200,  @purchase_price_paid_2.auction_price_without_vat
+    assert_equal 60,   @purchase_price_paid_3.auction_price_without_vat
   end
 
   test '#auction_price_with_vat' do
@@ -377,6 +393,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 372.0,     @delivery_offer_request.auction_price_with_vat
     assert_equal 111.6,     @delivery_ordered.auction_price_with_vat
     assert_equal 824.6,     @offer_accepted.auction_price_with_vat
+    assert_equal 10664.0,   @offer_accepted_2.auction_price_with_vat
     assert_equal 372.0,     @offer_automatically_accepted.auction_price_with_vat
     assert_equal 62.0,      @offer_declined.auction_price_with_vat
     assert_equal 372.0,     @purchase_price_paid.auction_price_with_vat

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -728,6 +728,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
         assert_includes email.messages, "Customer #{customer.id} was found, so updating existing customer info"
         assert_includes email.messages, "Customer #{customer.id} updated"
+
+        assert_equal customer, email.find_draft.customer
       end
     end
 
@@ -739,6 +741,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         email.update_or_create_customer
 
         assert_includes email.messages, "Customer #{Customer.last.id} created"
+
+        assert_equal Customer.last, email.find_draft.customer
       end
     end
   end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -307,7 +307,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 806.0,      @auction_ended.total_price_with_vat
     assert_equal 372.0,      @delivery_offer_request.total_price_with_vat
     assert_equal 824.6,      @offer_accepted.total_price_with_vat
-    assert_equal 10664.0,    @offer_accepted_2.total_price_with_vat
+    assert_equal 10_664.0,   @offer_accepted_2.total_price_with_vat
     assert_equal 372.0,      @offer_automatically_accepted.total_price_with_vat
     assert_equal 62.0,       @offer_declined.total_price_with_vat
     assert_equal 372.0,      @purchase_price_paid.total_price_with_vat
@@ -321,6 +321,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '270265', @delivery_offer_request.auction_id
     assert_equal '274472', @delivery_ordered.auction_id
     assert_equal '277075', @offer_accepted.auction_id
+    assert_equal '293363', @offer_accepted_2.auction_id
     assert_equal '270265', @offer_automatically_accepted.auction_id
     assert_equal '277687', @offer_declined.auction_id
     assert_equal '270265', @purchase_price_paid.auction_id
@@ -344,6 +345,9 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     title = '18.03.-25.03. SkyJack SJ III - 3219 saksilavanostin, Lahti'
     assert_equal title, @offer_accepted.auction_title
 
+    title = '26.04.-01.05. BOBCAT 320 kaivinkone, Lahti'
+    assert_equal title, @offer_accepted_2.auction_title
+
     title = '20.03.-25.03. Auton keinunostin, 1500 kg, UUSI, Lahti'
     assert_equal title, @offer_automatically_accepted.auction_title
 
@@ -366,6 +370,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal "2016-03-25 20:20".to_time, @delivery_offer_request.auction_closing_date
     assert_equal "2016-03-25 19:38".to_time, @delivery_ordered.auction_closing_date
     assert_equal "2016-03-25 20:10".to_time, @offer_accepted.auction_closing_date
+    assert_equal "2016-05-01 20:25".to_time, @offer_accepted_2.auction_closing_date
     assert_equal "2016-03-25 20:20".to_time, @offer_automatically_accepted.auction_closing_date
     assert_equal "2016-03-25 19:40".to_time, @offer_declined.auction_closing_date
     assert_equal "2016-03-25 20:20".to_time, @purchase_price_paid.auction_closing_date
@@ -393,7 +398,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 372.0,     @delivery_offer_request.auction_price_with_vat
     assert_equal 111.6,     @delivery_ordered.auction_price_with_vat
     assert_equal 824.6,     @offer_accepted.auction_price_with_vat
-    assert_equal 10664.0,   @offer_accepted_2.auction_price_with_vat
+    assert_equal 10_664.0,  @offer_accepted_2.auction_price_with_vat
     assert_equal 372.0,     @offer_automatically_accepted.auction_price_with_vat
     assert_equal 62.0,      @offer_declined.auction_price_with_vat
     assert_equal 372.0,     @purchase_price_paid.auction_price_with_vat
@@ -407,6 +412,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 24, @delivery_offer_request.auction_vat_percent
     assert_equal 24, @delivery_ordered.auction_vat_percent
     assert_equal 24, @offer_accepted.auction_vat_percent
+    assert_equal 24, @offer_accepted_2.auction_vat_percent
     assert_equal 24, @offer_automatically_accepted.auction_vat_percent
     assert_equal 24, @offer_declined.auction_vat_percent
     assert_equal 24, @purchase_price_paid.auction_vat_percent
@@ -415,16 +421,17 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#auction_vat_amount' do
-    assert_equal 156.0, @auction_ended.auction_vat_amount
-    assert_equal 40.8,  @bidder_picks_up.auction_vat_amount
-    assert_equal 72.0,  @delivery_offer_request.auction_vat_amount
-    assert_equal 21.6,  @delivery_ordered.auction_vat_amount
-    assert_equal 159.6, @offer_accepted.auction_vat_amount
-    assert_equal 72.0,  @offer_automatically_accepted.auction_vat_amount
-    assert_equal 12.0,  @offer_declined.auction_vat_amount
-    assert_equal 72.0,  @purchase_price_paid.auction_vat_amount
-    assert_equal 48.0,  @purchase_price_paid_2.auction_vat_amount
-    assert_equal 14.4,  @purchase_price_paid_3.auction_vat_amount
+    assert_equal 156.0,  @auction_ended.auction_vat_amount
+    assert_equal 40.8,   @bidder_picks_up.auction_vat_amount
+    assert_equal 72.0,   @delivery_offer_request.auction_vat_amount
+    assert_equal 21.6,   @delivery_ordered.auction_vat_amount
+    assert_equal 159.6,  @offer_accepted.auction_vat_amount
+    assert_equal 2064.0, @offer_accepted_2.auction_vat_amount
+    assert_equal 72.0,   @offer_automatically_accepted.auction_vat_amount
+    assert_equal 12.0,   @offer_declined.auction_vat_amount
+    assert_equal 72.0,   @purchase_price_paid.auction_vat_amount
+    assert_equal 48.0,   @purchase_price_paid_2.auction_vat_amount
+    assert_equal 14.4,   @purchase_price_paid_3.auction_vat_amount
   end
 
   test '#find_customer' do
@@ -432,6 +439,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal customers(:huutokauppa_customer_2), @offer_automatically_accepted.find_customer
     assert_equal customers(:huutokauppa_customer_2), @purchase_price_paid.find_customer
 
+    assert_nil @offer_accepted_2.find_customer
     assert_nil @purchase_price_paid_2.find_customer
     assert_nil @purchase_price_paid_3.find_customer
 
@@ -443,6 +451,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#create_customer' do
     [
       @offer_accepted,
+      @offer_accepted_2,
       @offer_automatically_accepted,
       @purchase_price_paid,
       @purchase_price_paid_2,
@@ -486,6 +495,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal sales_order_drafts(:huutokauppa_270265), @delivery_offer_request.find_draft
     assert_equal sales_order_drafts(:huutokauppa_274472), @delivery_ordered.find_draft
     assert_equal sales_order_drafts(:huutokauppa_277075), @offer_accepted.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_293363), @offer_accepted_2.find_draft
     assert_equal sales_order_drafts(:huutokauppa_270265), @offer_automatically_accepted.find_draft
     assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_draft
     assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_draft
@@ -496,6 +506,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#update_order_customer_info' do
     [
       @offer_accepted,
+      @offer_accepted_2,
       @offer_automatically_accepted,
       @purchase_price_paid,
       @purchase_price_paid_2,
@@ -568,6 +579,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_offer_request,
       @delivery_ordered,
       @offer_accepted,
+      @offer_accepted_2,
       @offer_automatically_accepted,
       @offer_declined,
       @purchase_price_paid,
@@ -608,6 +620,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     LegacyMethods.stub :pupesoft_function, sales_order_creation do
       [
         @offer_accepted,
+        @offer_accepted_2,
         @offer_automatically_accepted,
         @purchase_price_paid,
         @purchase_price_paid_2,
@@ -654,6 +667,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @bidder_picks_up,
       @delivery_offer_request,
       @offer_accepted,
+      @offer_accepted_2,
       @offer_automatically_accepted,
       @offer_declined,
       @purchase_price_paid,
@@ -674,6 +688,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_offer_request,
       @delivery_ordered,
       @offer_accepted,
+      @offer_accepted_2,
       @offer_automatically_accepted,
       @offer_declined,
       @purchase_price_paid,
@@ -694,6 +709,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_offer_request,
       @delivery_ordered,
       @offer_accepted,
+      @offer_accepted_2,
       @offer_declined,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
@@ -716,6 +732,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_offer_request,
       @delivery_ordered,
       @offer_accepted,
+      @offer_accepted_2,
       @offer_declined,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
@@ -759,6 +776,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
 
     [
+      @offer_accepted_2,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
     ].each do |email|

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -494,7 +494,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_difference 'Customer.count' do
         email.create_customer
 
-        assert_includes email.messages, "Asiakas #{Customer.last.id} luotu."
+        assert_includes email.messages, "Asiakas #{Customer.last.nimi} (#{Customer.last.email}) luotu."
       end
     end
 
@@ -511,7 +511,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
       assert email.update_customer
 
-      assert_includes email.messages, "Asiakas #{email.find_customer.id} päivitetty."
+      assert_includes email.messages, "Asiakas #{email.find_customer.nimi} (#{email.find_customer.email}) päivitetty."
     end
 
     @emails_without_customer_info.each do |email|
@@ -569,7 +569,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_empty email.find_draft.laskutus_postitp
       assert_empty email.find_draft.laskutus_maa
 
-      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_draft.id} asiakastiedot."
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) asiakastiedot."
+      assert_includes email.messages, message
     end
 
     @emails_without_customer_info.each do |email|
@@ -594,7 +595,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_equal email.delivery_phone,    email.find_order.toim_puh
       assert_equal email.delivery_postcode, email.find_order.toim_postino
 
-      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_order.id} toimitustiedot."
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_order.id}, Huutokauppa: #{email.auction_id}) toimitustiedot."
+      assert_includes email.messages, message
     end
 
     @emails_without_delivery_info.each do |email|
@@ -628,7 +630,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_equal email.auction_title,             email.find_draft.rows.first.nimitys
       assert_equal email.auction_vat_percent,       email.find_draft.rows.first.alv
 
-      message = "Päivitettiin tilauksen #{email.find_draft.id} rivin #{email.find_draft.rows.first.id} tuotetiedot."
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) tuotetiedot."
       assert_includes email.messages, message
     end
   end
@@ -689,7 +691,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         assert_difference 'SalesOrder::Row.count' do
           email.add_delivery_row
 
-          assert_includes email.messages, "Lisättiin toimitusrivi #{row.id} tilaukselle #{email.find_draft.id}."
+          message = "Lisättiin toimitusrivi tilaukselle (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id})."
+          assert_includes email.messages, message
         end
       end
     end
@@ -730,7 +733,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       email.update_delivery_method_to_nouto
 
       assert_equal delivery_methods(:nouto), email.find_draft.delivery_method
-      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_draft.id} toimitustavaksi Nouto."
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) toimitustavaksi Nouto."
+      assert_includes email.messages, message
     end
   end
 
@@ -753,7 +757,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       email.update_delivery_method_to_itella_economy_16
 
       assert_equal delivery_methods(:itella_economy_16), email.find_order.delivery_method
-      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_order.id} toimitustavaksi Itella Economy 16."
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_order.id}, Huutokauppa: #{email.auction_id}) toimitustavaksi Itella Economy 16."
+      assert_includes email.messages, message
     end
   end
 
@@ -781,7 +786,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
           assert_difference 'SalesOrder::Order.count' do
             email.mark_as_done
 
-            assert_includes email.messages, "Merkittiin tilaus #{email.find_order.id} valmiiksi."
+            message = "Merkittiin tilaus (Tilausnumero: #{email.find_order.id}, Huutokauppa: #{email.auction_id}) valmiiksi."
+            assert_includes email.messages, message
           end
         end
       end
@@ -800,8 +806,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         assert_equal email.find_customer, customer
         assert_equal email.customer_name, customer.nimi
 
-        assert_includes email.messages, "Asiakas #{customer.id} löytyi, joten päivitetään kyseisen asiakkaan tiedot."
-        assert_includes email.messages, "Asiakas #{customer.id} päivitetty."
+        assert_includes email.messages, "Asiakas #{customer.nimi} (#{customer.email}) löytyi, joten päivitetään kyseisen asiakkaan tiedot."
+        assert_includes email.messages, "Asiakas #{customer.nimi} (#{customer.email}) päivitetty."
 
         assert_equal customer, email.find_draft.customer
       end
@@ -815,7 +821,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_difference 'Customer.count' do
         email.update_or_create_customer
 
-        assert_includes email.messages, "Asiakas #{Customer.last.id} luotu."
+        assert_includes email.messages, "Asiakas #{Customer.last.nimi} (#{Customer.last.email}) luotu."
 
         assert_equal Customer.last, email.find_draft.customer
       end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -494,7 +494,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_difference 'Customer.count' do
         email.create_customer
 
-        assert_includes email.messages, "Customer #{Customer.last.id} created"
+        assert_includes email.messages, "Asiakas #{Customer.last.id} luotu."
       end
     end
 
@@ -511,7 +511,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
       assert email.update_customer
 
-      assert_includes email.messages, "Customer #{email.find_customer.id} updated"
+      assert_includes email.messages, "Asiakas #{email.find_customer.id} päivitetty."
     end
 
     @emails_without_customer_info.each do |email|
@@ -569,7 +569,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_empty email.find_draft.laskutus_postitp
       assert_empty email.find_draft.laskutus_maa
 
-      assert_includes email.messages, "Updated order #{email.find_draft.id} customer info"
+      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_draft.id} asiakastiedot."
     end
 
     @emails_without_customer_info.each do |email|
@@ -594,7 +594,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_equal email.delivery_phone,    email.find_order.toim_puh
       assert_equal email.delivery_postcode, email.find_order.toim_postino
 
-      assert_includes email.messages, "Updated order #{email.find_order.id} delivery_info"
+      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_order.id} toimitustiedot."
     end
 
     @emails_without_delivery_info.each do |email|
@@ -628,8 +628,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_equal email.auction_title,             email.find_draft.rows.first.nimitys
       assert_equal email.auction_vat_percent,       email.find_draft.rows.first.alv
 
-      assert_includes email.messages,
-                      "Updated order #{email.find_draft.id} row #{email.find_draft.rows.first.id} product info"
+      message = "Päivitettiin tilauksen #{email.find_draft.id} rivin #{email.find_draft.rows.first.id} tuotetiedot."
+      assert_includes email.messages, message
     end
   end
 
@@ -689,7 +689,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         assert_difference 'SalesOrder::Row.count' do
           email.add_delivery_row
 
-          assert_includes email.messages, "Added delivery row #{row.id} for order #{email.find_draft.id}"
+          assert_includes email.messages, "Lisättiin toimitusrivi #{row.id} tilaukselle #{email.find_draft.id}."
         end
       end
     end
@@ -730,7 +730,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       email.update_delivery_method_to_nouto
 
       assert_equal delivery_methods(:nouto), email.find_draft.delivery_method
-      assert_includes email.messages, "Updated order #{email.find_draft.id} delivery method to Nouto"
+      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_draft.id} toimitustavaksi Nouto."
     end
   end
 
@@ -753,7 +753,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       email.update_delivery_method_to_itella_economy_16
 
       assert_equal delivery_methods(:itella_economy_16), email.find_order.delivery_method
-      assert_includes email.messages, "Updated order #{email.find_order.id} delivery method to Itella Economy 16"
+      assert_includes email.messages, "Päivitettiin tilauksen #{email.find_order.id} toimitustavaksi Itella Economy 16."
     end
   end
 
@@ -781,7 +781,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
           assert_difference 'SalesOrder::Order.count' do
             email.mark_as_done
 
-            assert_includes email.messages, "Marked order #{email.find_order.id} as done"
+            assert_includes email.messages, "Merkittiin tilaus #{email.find_order.id} valmiiksi."
           end
         end
       end
@@ -800,8 +800,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         assert_equal email.find_customer, customer
         assert_equal email.customer_name, customer.nimi
 
-        assert_includes email.messages, "Customer #{customer.id} was found, so updating existing customer info"
-        assert_includes email.messages, "Customer #{customer.id} updated"
+        assert_includes email.messages, "Asiakas #{customer.id} löytyi, joten päivitetään kyseisen asiakkaan tiedot."
+        assert_includes email.messages, "Asiakas #{customer.id} päivitetty."
 
         assert_equal customer, email.find_draft.customer
       end
@@ -815,7 +815,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_difference 'Customer.count' do
         email.update_or_create_customer
 
-        assert_includes email.messages, "Customer #{Customer.last.id} created"
+        assert_includes email.messages, "Asiakas #{Customer.last.id} luotu."
 
         assert_equal Customer.last, email.find_draft.customer
       end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -92,6 +92,22 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal :purchase_price_paid,          @purchase_price_paid_3.type
   end
 
+  test '#company_name' do
+    assert_equal 'Testites Oy', @offer_accepted_2.company_name
+
+    assert_nil @auction_ended.company_name
+    assert_nil @bidder_picks_up.company_name
+    assert_nil @delivery_offer_request.company_name
+    assert_nil @delivery_ordered.company_name
+    assert_nil @invalid_customer_info.company_name
+    assert_nil @offer_accepted.company_name
+    assert_nil @offer_automatically_accepted.company_name
+    assert_nil @offer_declined.company_name
+    assert_nil @purchase_price_paid.company_name
+    assert_nil @purchase_price_paid_2.company_name
+    assert_nil @purchase_price_paid_3.company_name
+  end
+
   test '#customer_name' do
     assert_equal 'Testi Testit Testitestit', @offer_accepted.customer_name
     assert_equal 'Testi Testiä',             @offer_accepted_2.customer_name

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -589,6 +589,14 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#update_order_product_info with tuoteperhe calls legacy method' do
+    @offer_accepted.find_draft.rows.first.update!(perheid: 1)
+
+    LegacyMethods.stub :pupesoft_function, proc { raise ScriptError } do
+      assert_raise(ScriptError) { @offer_accepted.update_order_product_info }
+    end
+  end
+
   test '#create_sales_order' do
     sales_order_creation = proc do
       sales_order = SalesOrder::Draft.new

--- a/test/controllers/administration/incoming_mails_controller_test.rb
+++ b/test/controllers/administration/incoming_mails_controller_test.rb
@@ -25,7 +25,7 @@ class Administration::IncomingMailsControllerTest < ActionController::TestCase
       assert_equal incoming_mail.mail_server.to_s,    css_select(row, 'td')[0].content
       assert_equal processed_at,                      css_select(row, 'td')[1].content
       assert_equal incoming_mail.status.to_s,         css_select(row, 'td')[2].content
-      assert_equal incoming_mail.status_message.to_s, css_select(row, 'td')[3].content
+      assert_includes css_select(row, 'td')[3].content, incoming_mail.status_message.to_s
     end
   end
 end

--- a/test/fixtures/head_details.yml
+++ b/test/fixtures/head_details.yml
@@ -14,7 +14,7 @@ two:
   head: pi_H
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363].each do |auction_id| %>
 huutokauppa_<%= auction_id %>_detail:
   head: huutokauppa_<%= auction_id %>
   laskutus_nimi: Testi Testaaja

--- a/test/fixtures/heads.yml
+++ b/test/fixtures/heads.yml
@@ -3,6 +3,7 @@
 pi_<%= i %>:
   yhtio: acme
   tila: <%= i %>
+  customer: stubborn_customer
   luontiaika: <%= Time.now %>
   laatija: joe
   muutospvm: <%= Time.now %>
@@ -30,6 +31,7 @@ pi_<%= i %>:
 si_one:
   yhtio: acme
   tila: U
+  customer: lissu
   luontiaika: <%= Time.now %>
   laatija: joe
   muutospvm: <%= Time.now %>

--- a/test/fixtures/sales_order/drafts.yml
+++ b/test/fixtures/sales_order/drafts.yml
@@ -28,7 +28,7 @@ not_finished_order:
   terms_of_payment: hundred_days_net
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363].each do |auction_id| %>
 huutokauppa_<%= auction_id %>:
   toim_nimi: Testi Testaaja
   toim_nimitark: Testi Testaaja

--- a/test/fixtures/sales_order/rows.yml
+++ b/test/fixtures/sales_order/rows.yml
@@ -13,7 +13,7 @@ so_row_one:
   tyyppi: L
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363].each do |auction_id| %>
 huutokauppa_<%= auction_id %>_row_1:
   order: huutokauppa_<%= auction_id %>
   tuoteno: hammer123

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -36,7 +36,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 665, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{sales_order.id} asiakastiedot."
+    message = "Päivitettiin tilauksen (Tilausnumero: #{sales_order.id}, Huutokauppa: #{sales_order.viesti}) asiakastiedot."
+    assert_includes incoming_mail.reload.status_message, message
 
     incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
     incoming_mail.save!
@@ -51,7 +52,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 300, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{sales_order.id} asiakastiedot."
+    message = "Päivitettiin tilauksen (Tilausnumero: #{sales_order.id}, Huutokauppa: #{sales_order.viesti}) asiakastiedot."
+    assert_includes incoming_mail.reload.status_message, message
   end
 
   test 'customer is created and customer and product info are updated correctly to order when customer is not found' do
@@ -72,7 +74,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 665, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Asiakas #{Customer.last.id} luotu."
+    assert_includes incoming_mail.reload.status_message, "Asiakas #{Customer.last.nimi} (#{Customer.last.email}) luotu."
 
     incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
     incoming_mail.save!
@@ -87,7 +89,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 300, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    messsage = "Päivitettiin tilauksen #{sales_order.id} rivin #{sales_order.rows.first.id} tuotetiedot"
+    messsage = "Päivitettiin tilauksen (Tilausnumero: #{sales_order.id}, Huutokauppa: #{sales_order.viesti}) tuotetiedot"
     assert_includes incoming_mail.reload.status_message, messsage
   end
 
@@ -130,7 +132,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal delivery_methods(:nouto), order.delivery_method
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{order.id} toimitustavaksi Nouto."
+    message = "Päivitettiin tilauksen (Tilausnumero: #{order.id}, Huutokauppa: #{order.viesti}) toimitustavaksi Nouto."
+    assert_includes incoming_mail.reload.status_message, message
   end
 
   test 'order delivery info is updated and delivery method set when type is delivery ordered' do
@@ -151,6 +154,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal delivery_methods(:itella_economy_16), order.delivery_method
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{order.id} toimitustiedot."
+    message = "Päivitettiin tilauksen (Tilausnumero: #{order.id}, Huutokauppa: #{order.viesti}) toimitustiedot."
+    assert_includes incoming_mail.reload.status_message, message
   end
 end

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -35,6 +35,9 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 'Testi Testit Testitestit', sales_order.nimi
     assert_equal 665, sales_order.rows.first.rivihinta
 
+    assert_equal 'ok', incoming_mail.reload.status
+    assert_includes incoming_mail.reload.status_message, "Updated order #{sales_order.id} customer info"
+
     incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
     incoming_mail.save!
 
@@ -48,7 +51,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 300, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_nil incoming_mail.reload.status_message
+    assert_includes incoming_mail.reload.status_message, "Updated order #{sales_order.id} customer info"
   end
 
   test 'customer is created and customer and product info are updated correctly to order when customer is not found' do
@@ -68,6 +71,9 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 'Testi Testit Testitestit', sales_order.nimi
     assert_equal 665, sales_order.rows.first.rivihinta
 
+    assert_equal 'ok', incoming_mail.reload.status
+    assert_includes incoming_mail.reload.status_message, "Customer #{Customer.last.id} created"
+
     incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
     incoming_mail.save!
 
@@ -81,7 +87,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 300, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_nil incoming_mail.reload.status_message
+    assert_includes incoming_mail.reload.status_message,
+                    "Updated order #{sales_order.id} row #{sales_order.rows.first.id} product info"
   end
 
   test 'error is logged if exception is thrown' do
@@ -123,7 +130,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal delivery_methods(:nouto), order.delivery_method
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_nil incoming_mail.reload.status_message
+    assert_includes incoming_mail.reload.status_message, "Updated order #{order.id} delivery method to Nouto"
   end
 
   test 'order delivery info is updated and delivery method set when type is delivery ordered' do
@@ -144,6 +151,6 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal delivery_methods(:itella_economy_16), order.delivery_method
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_nil incoming_mail.reload.status_message
+    assert_includes incoming_mail.reload.status_message, "Updated order #{order.id} delivery_info"
   end
 end

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -36,7 +36,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 665, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Updated order #{sales_order.id} customer info"
+    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{sales_order.id} asiakastiedot."
 
     incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
     incoming_mail.save!
@@ -51,7 +51,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 300, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Updated order #{sales_order.id} customer info"
+    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{sales_order.id} asiakastiedot."
   end
 
   test 'customer is created and customer and product info are updated correctly to order when customer is not found' do
@@ -72,7 +72,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 665, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Customer #{Customer.last.id} created"
+    assert_includes incoming_mail.reload.status_message, "Asiakas #{Customer.last.id} luotu."
 
     incoming_mail.raw_source = huutokauppa_email(:offer_automatically_accepted_1)
     incoming_mail.save!
@@ -87,8 +87,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal 300, sales_order.rows.first.rivihinta
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message,
-                    "Updated order #{sales_order.id} row #{sales_order.rows.first.id} product info"
+    messsage = "Päivitettiin tilauksen #{sales_order.id} rivin #{sales_order.rows.first.id} tuotetiedot"
+    assert_includes incoming_mail.reload.status_message, messsage
   end
 
   test 'error is logged if exception is thrown' do
@@ -130,7 +130,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal delivery_methods(:nouto), order.delivery_method
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Updated order #{order.id} delivery method to Nouto"
+    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{order.id} toimitustavaksi Nouto."
   end
 
   test 'order delivery info is updated and delivery method set when type is delivery ordered' do
@@ -151,6 +151,6 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     assert_equal delivery_methods(:itella_economy_16), order.delivery_method
 
     assert_equal 'ok', incoming_mail.reload.status
-    assert_includes incoming_mail.reload.status_message, "Updated order #{order.id} delivery_info"
+    assert_includes incoming_mail.reload.status_message, "Päivitettiin tilauksen #{order.id} toimitustiedot."
   end
 end

--- a/test/models/customer_test.rb
+++ b/test/models/customer_test.rb
@@ -7,6 +7,7 @@ class CustomerTest < ActiveSupport::TestCase
     customer_prices
     customers
     delivery_methods
+    heads
     keyword/customer_categories
     keyword/customer_subcategories
     keywords
@@ -39,6 +40,7 @@ class CustomerTest < ActiveSupport::TestCase
     assert @one.prices.count > 0
     assert @one.products.count > 0
     assert_equal "9", @one.sales_details.first.tila
+    refute_empty @one.heads
   end
 
   test 'contract_price?' do

--- a/test/models/head_test.rb
+++ b/test/models/head_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class HeadTest < ActiveSupport::TestCase
   fixtures %w(
+    customers
     head_details
     heads
   )
@@ -17,5 +18,8 @@ class HeadTest < ActiveSupport::TestCase
   test 'associations' do
     assert_equal head_details(:two), heads(:pi_H).detail
     assert_equal head_details(:one), heads(:si_one).detail
+
+    assert_equal customers(:stubborn_customer), heads(:pi_H).customer
+    assert_equal customers(:lissu),             heads(:si_one).customer
   end
 end


### PR DESCRIPTION
* Log successful HuutokauppaMail actions
* Add second offer accepted email
* Add customer association to Head and vice versa
* Associate created customers with order
* Accept all space characters in numbers in regex
* Support tuoteperheet
* Add methods for fetching company name and id from email
* Update ytunnus with company id if found
* Empty customer nimitark when updating order customer information