### PR TITLE
Huutokauppa fixes

### DIFF
--- a/app/assets/stylesheets/static/pupesoft.scss
+++ b/app/assets/stylesheets/static/pupesoft.scss
@@ -289,3 +289,7 @@ td.separator {
   display: block;
   margin-bottom: 5px;
 }
+
+strong {
+  font-weight: bold;
+}

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -217,7 +217,12 @@ class HuutokauppaMail
   end
 
   def find_draft
-    @draft ||= SalesOrder::Draft.find_by!(viesti: auction_id)
+    @draft ||= SalesOrder::Draft.find_by(viesti: auction_id)
+
+    return @draft if @draft
+
+    @messages << "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{auction_id}."
+    nil
   end
 
   def find_order

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -158,7 +158,7 @@ class HuutokauppaMail
   def create_customer
     return unless customer_name
 
-    customer = Customer.create!(
+    customer = Customer.new(
       email: customer_email,
       gsm: customer_phone,
       kauppatapahtuman_luonne: Keyword::NatureOfTransaction.first.selite,
@@ -169,8 +169,13 @@ class HuutokauppaMail
       ytunnus: company_id || auction_id,
     )
 
-    @messages << "Asiakas #{customer_message_info(customer)} luotu."
+    if customer.save
+      @messages << "Asiakas #{customer_message_info(customer)} luotu."
+      return customer
+    end
 
+    @messages << "Asiakkaan #{customer_message_info(customer)} luonti epäonnistui. " \
+                 "Virheilmoitus: #{customer.errors.full_messages.to_sentence}."
     customer
   end
 

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -226,7 +226,12 @@ class HuutokauppaMail
   end
 
   def find_order
-    @order ||= SalesOrder::Order.find_by!(viesti: auction_id)
+    @order ||= SalesOrder::Order.find_by(viesti: auction_id)
+
+    return @order if @order
+
+    @messages << "Myyntitilausta ei löytynyt huutokaupalle #{auction_id}."
+    nil
   end
 
   def update_order_customer_info

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -177,7 +177,7 @@ class HuutokauppaMail
   def update_customer
     return unless find_customer
 
-    find_customer.update!(
+    update_success = find_customer.update(
       gsm: customer_phone,
       nimi: customer_name,
       osoite: customer_address,
@@ -185,11 +185,13 @@ class HuutokauppaMail
       postitp: customer_city,
     )
 
-    @messages << "Asiakas #{customer_message_info(find_customer)} päivitetty."
+    if update_success
+      @messages << "Asiakas #{customer_message_info(find_customer)} päivitetty."
+      return true
+    end
 
-    true
-  rescue ActiveRecord::RecordInvalid => e
-    @messages << "Asiakkaan #{customer_message_info(find_customer)} tietojen päivitys epäonnistui. Virheilmoitus: #{e.message}."
+    @messages << "Asiakkaan #{customer_message_info(find_customer)} tietojen päivitys epäonnistui. " \
+                 "Virheilmoitus: #{find_customer.errors.full_messages.to_sentence}."
     false
   end
 

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -272,7 +272,9 @@ class HuutokauppaMail
   def update_order_delivery_info
     return unless delivery_name
 
-    find_order.update!(
+    order = find_order || find_draft
+
+    order.update!(
       toim_email: delivery_email,
       toim_nimi: delivery_name,
       toim_osoite: delivery_address,
@@ -281,7 +283,7 @@ class HuutokauppaMail
       toim_puh: delivery_phone,
     )
 
-    @messages << "Päivitettiin tilauksen #{order_message_info(find_order)} toimitustiedot."
+    @messages << "Päivitettiin tilauksen #{order_message_info(order)} toimitustiedot."
 
     true
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -188,6 +188,9 @@ class HuutokauppaMail
     @messages << "Asiakas #{customer_message_info(find_customer)} päivitetty."
 
     true
+  rescue ActiveRecord::RecordInvalid => e
+    @messages << "Asiakkaan #{customer_message_info(find_customer)} tietojen päivitys epäonnistui. Virheilmoitus: #{e.message}."
+    false
   end
 
   def update_or_create_customer

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -299,7 +299,7 @@ class HuutokauppaMail
       rivihinta_valuutassa: auction_price_without_vat,
     )
 
-    if row.perheid != 0
+    if row.parent?
       child_row_ids = find_draft.rows.where.not(tunnus: row.tunnus).pluck(:tunnus)
       LegacyMethods.pupesoft_function(:tuoteperheiden_hintojen_paivitys, parent_row_ids: { row.id => child_row_ids })
     end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -304,7 +304,7 @@ class HuutokauppaMail
       LegacyMethods.pupesoft_function(:tuoteperheiden_hintojen_paivitys, parent_row_ids: { row.id => child_row_ids })
     end
 
-    @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} tuotetiedot."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} tuotetiedot (Tuoteno: #{row.tuoteno}, Hinta: #{row.hinta})."
 
     true
   end
@@ -328,7 +328,7 @@ class HuutokauppaMail
                      .order(:myyntihinta)
                      .first!
 
-    @messages << "Löydettiin tuote #{product.tuoteno} lisättäväksi toimitustuotteeksi."
+    @messages << "Löydettiin tuote (Tuoteno: #{product.tuoteno}, Hinta: #{product.myyntihinta}) lisättäväksi toimitustuotteeksi."
 
     response = LegacyMethods.pupesoft_function(:lisaa_rivi, order_id: find_draft.id, product_id: product.id)
 

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -221,7 +221,8 @@ class HuutokauppaMail
 
     return @draft if @draft
 
-    raise "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{auction_id}."
+    @messages << "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{auction_id}."
+    nil
   end
 
   def find_order

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -201,6 +201,8 @@ class HuutokauppaMail
   end
 
   def update_or_create_customer
+    return unless find_draft
+
     if find_customer
       @messages << "Asiakas #{customer_message_info(find_customer)} löytyi, joten päivitetään kyseisen asiakkaan tiedot."
 
@@ -235,7 +237,7 @@ class HuutokauppaMail
   end
 
   def update_order_customer_info
-    return unless customer_name
+    return unless customer_name && find_draft
 
     find_draft.update!(
       nimi: customer_name,
@@ -274,6 +276,8 @@ class HuutokauppaMail
 
     order = find_order || find_draft
 
+    return unless order
+
     order.update!(
       toim_email: delivery_email,
       toim_nimi: delivery_name,
@@ -289,6 +293,8 @@ class HuutokauppaMail
   end
 
   def update_order_product_info
+    return unless find_draft
+
     row = find_draft.rows.first
 
     row.update!(
@@ -323,7 +329,7 @@ class HuutokauppaMail
   end
 
   def add_delivery_row
-    return unless delivery_price_with_vat && delivery_price_with_vat > 0
+    return unless find_draft && delivery_price_with_vat && delivery_price_with_vat > 0
 
     product = Product.where(tuoteno: DELIVERY_PRODUCT_NUMBERS)
                      .where('round(myyntihinta * 1.24, 2) >= ?', delivery_price_with_vat)
@@ -342,6 +348,8 @@ class HuutokauppaMail
   end
 
   def update_delivery_method_to_nouto
+    return unless find_draft
+
     find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'))
 
     @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} toimitustavaksi Nouto."
@@ -352,6 +360,8 @@ class HuutokauppaMail
   def update_delivery_method_to_itella_economy_16
     order = find_order || find_draft
 
+    return unless order
+
     order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
 
     @messages << "Päivitettiin tilauksen #{order_message_info(order)} toimitustavaksi Itella Economy 16."
@@ -360,6 +370,8 @@ class HuutokauppaMail
   end
 
   def mark_as_done
+    return unless find_draft
+
     response = find_draft.mark_as_done(create_preliminary_invoice: true)
 
     @messages << "Merkittiin tilaus #{order_message_info(find_draft)} valmiiksi."

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -223,26 +223,25 @@ class HuutokauppaMail
       osoite: customer_address,
       postino: customer_postcode,
       postitp: customer_city,
-      email: customer_email,
       puh: customer_phone,
+      email: customer_email,
       ytunnus: company_id || auction_id,
-      toim_nimi: '',
+
+      toim_nimi: customer_name,
       toim_nimitark: '',
-      toim_osoite: '',
-      toim_postino: '',
-      toim_postitp: '',
-      toim_maa: '',
-      toim_puh: '',
-      toim_email: '',
+      toim_osoite: customer_address,
+      toim_postino: customer_postcode,
+      toim_postitp: customer_city,
+      toim_puh: customer_phone,
+      toim_email: customer_email,
     )
 
     find_draft.detail.update!(
-      laskutus_nimi: '',
+      laskutus_nimi: customer_name,
       laskutus_nimitark: '',
-      laskutus_osoite: '',
-      laskutus_postino: '',
-      laskutus_postitp: '',
-      laskutus_maa: '',
+      laskutus_osoite: customer_address,
+      laskutus_postino: customer_postcode,
+      laskutus_postitp: customer_city,
     )
 
     @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} asiakastiedot."

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -221,8 +221,7 @@ class HuutokauppaMail
 
     return @draft if @draft
 
-    @messages << "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{auction_id}."
-    nil
+    raise "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{auction_id}."
   end
 
   def find_order

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -350,9 +350,11 @@ class HuutokauppaMail
   end
 
   def update_delivery_method_to_itella_economy_16
-    find_order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
+    order = find_order || find_draft
 
-    @messages << "Päivitettiin tilauksen #{order_message_info(find_order)} toimitustavaksi Itella Economy 16."
+    order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
+
+    @messages << "Päivitettiin tilauksen #{order_message_info(order)} toimitustavaksi Itella Economy 16."
 
     true
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -166,7 +166,7 @@ class HuutokauppaMail
       osoite: customer_address,
       postino: customer_postcode,
       postitp: customer_city,
-      ytunnus: company_id || auction_id,
+      ytunnus: company_id || "HK#{auction_id}",
     )
 
     if customer.save

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -37,6 +37,7 @@ class HuutokauppaJob < ActiveJob::Base
       @huutokauppa_mail.update_or_create_customer
       @huutokauppa_mail.update_order_customer_info
       @huutokauppa_mail.update_order_product_info
+      @huutokauppa_mail.update_delivery_method_to_nouto
       true
     rescue => e
       log_error(e)
@@ -44,7 +45,6 @@ class HuutokauppaJob < ActiveJob::Base
     end
 
     def mark_order_as_done_and_set_delivery_method
-      @huutokauppa_mail.update_delivery_method_to_nouto
       @huutokauppa_mail.add_delivery_row
       @huutokauppa_mail.mark_as_done
       true

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -9,6 +9,8 @@ class HuutokauppaJob < ActiveJob::Base
 
     @huutokauppa_mail = HuutokauppaMail.new(@incoming_mail.raw_source)
 
+    @huutokauppa_mail.messages << "Aloitetaan #{@huutokauppa_mail.type.to_s.humanize}-tyyppisen sähköpostin käsittely."
+
     success = case @huutokauppa_mail.type
               when :offer_accepted, :offer_automatically_accepted
                 update_order_customer_and_product_info

--- a/app/jobs/huutokauppa_job.rb
+++ b/app/jobs/huutokauppa_job.rb
@@ -9,8 +9,6 @@ class HuutokauppaJob < ActiveJob::Base
 
     @huutokauppa_mail = HuutokauppaMail.new(@incoming_mail.raw_source)
 
-    @huutokauppa_mail.messages << "Aloitetaan #{@huutokauppa_mail.type.to_s.humanize}-tyyppisen sähköpostin käsittely."
-
     success = case @huutokauppa_mail.type
               when :offer_accepted, :offer_automatically_accepted
                 update_order_customer_and_product_info

--- a/app/models/incoming_mail.rb
+++ b/app/models/incoming_mail.rb
@@ -7,4 +7,10 @@ class IncomingMail < ActiveRecord::Base
   enum status: [:ok, :error]
 
   validates :raw_source, presence: true
+
+  delegate :subject, to: :mail, allow_nil: true
+
+  def mail
+    @mail ||= Mail.new(raw_source)
+  end
 end

--- a/app/models/row.rb
+++ b/app/models/row.rb
@@ -12,6 +12,10 @@ class Row < BaseModel
   self.primary_key = :tunnus
   self.inheritance_column = :tyyppi
 
+  def parent?
+    tunnus == perheid
+  end
+
   def self.default_child_instance
     child_class 'O'
   end

--- a/app/views/administration/incoming_mails/index.html.erb
+++ b/app/views/administration/incoming_mails/index.html.erb
@@ -39,6 +39,8 @@
           <td><%= l(incoming_mail.processed_at) if incoming_mail.processed_at %></td>
           <td><%= incoming_mail.status %></td>
           <td>
+            <strong><%= incoming_mail.subject %></strong>
+
             <% if incoming_mail.status_message %>
               <ul>
                 <% incoming_mail.status_message.split("\n").each do |message| %>

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -521,6 +521,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#update_customer logs errors' do
+    @offer_accepted.find_customer.update_column(:ytunnus, '')
+
+    refute @offer_accepted.update_customer
+
+    message = "Asiakkaan #{@offer_accepted.find_customer.nimi} (#{@offer_accepted.find_customer.email}) " \
+              "tietojen päivitys epäonnistui."
+    assert_includes @offer_accepted.messages.to_s, message
+  end
+
   test '#find_draft' do
     assert_equal sales_order_drafts(:huutokauppa_279590), @auction_ended.find_draft
     assert_equal sales_order_drafts(:huutokauppa_285888), @bidder_picks_up.find_draft

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -657,8 +657,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_equal email.auction_title,             email.find_draft.rows.first.nimitys
       assert_equal email.auction_vat_percent,       email.find_draft.rows.first.alv
 
-      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) tuotetiedot."
-      assert_includes email.messages, message
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) tuotetiedot"
+      assert_includes email.messages.to_s, message
     end
   end
 

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -557,9 +557,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#find_draft logs errors' do
     sales_order_drafts(:huutokauppa_279590).delete
-
-    assert_nil @auction_ended.find_draft
-    assert_includes @auction_ended.messages, "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{@auction_ended.auction_id}."
+    exception = assert_raise { @auction_ended.find_draft }
+    assert_equal "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{@auction_ended.auction_id}.", exception.message
   end
 
   test '#update_order_customer_info' do

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -663,7 +663,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#update_order_product_info with tuoteperhe calls legacy method' do
-    @offer_accepted.find_draft.rows.first.update!(perheid: 1)
+    row = @offer_accepted.find_draft.rows.first
+    row.update!(perheid: row.tunnus)
 
     LegacyMethods.stub :pupesoft_function, proc { raise ScriptError } do
       assert_raise(ScriptError) { @offer_accepted.update_order_product_info }

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -546,28 +546,28 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     ].each do |email|
       assert email.update_order_customer_info
 
-      assert_equal email.customer_address,  email.find_draft.osoite
-      assert_equal email.customer_city,     email.find_draft.postitp
-      assert_equal email.customer_email,    email.find_draft.email
       assert_equal email.customer_name,     email.find_draft.nimi
-      assert_equal email.customer_phone,    email.find_draft.puh
+      assert_empty                          email.find_draft.nimitark
+      assert_equal email.customer_address,  email.find_draft.osoite
+      assert_empty                          email.find_draft.osoitetark
       assert_equal email.customer_postcode, email.find_draft.postino
+      assert_equal email.customer_city,     email.find_draft.postitp
+      assert_equal email.customer_phone,    email.find_draft.puh
+      assert_equal email.customer_email,    email.find_draft.email
 
-      assert_empty email.find_draft.toim_nimi
-      assert_empty email.find_draft.toim_nimitark
-      assert_empty email.find_draft.toim_osoite
-      assert_empty email.find_draft.toim_postino
-      assert_empty email.find_draft.toim_postitp
-      assert_empty email.find_draft.toim_maa
-      assert_empty email.find_draft.toim_puh
-      assert_empty email.find_draft.toim_email
+      assert_equal email.customer_name,     email.find_draft.toim_nimi
+      assert_empty                          email.find_draft.toim_nimitark
+      assert_equal email.customer_address,  email.find_draft.toim_osoite
+      assert_equal email.customer_postcode, email.find_draft.toim_postino
+      assert_equal email.customer_city,     email.find_draft.toim_postitp
+      assert_equal email.customer_phone,    email.find_draft.toim_puh
+      assert_equal email.customer_email,    email.find_draft.toim_email
 
-      assert_empty email.find_draft.laskutus_nimi
-      assert_empty email.find_draft.laskutus_nimitark
-      assert_empty email.find_draft.laskutus_osoite
-      assert_empty email.find_draft.laskutus_postino
-      assert_empty email.find_draft.laskutus_postitp
-      assert_empty email.find_draft.laskutus_maa
+      assert_equal email.customer_name,     email.find_draft.laskutus_nimi
+      assert_empty                          email.find_draft.laskutus_nimitark
+      assert_equal email.customer_address,  email.find_draft.laskutus_osoite
+      assert_equal email.customer_postcode, email.find_draft.laskutus_postino
+      assert_equal email.customer_city,     email.find_draft.laskutus_postitp
 
       message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) asiakastiedot."
       assert_includes email.messages, message

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -555,6 +555,13 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal sales_order_drafts(:huutokauppa_285703), @purchase_price_paid_3.find_draft
   end
 
+  test '#find_draft logs errors' do
+    sales_order_drafts(:huutokauppa_279590).delete
+
+    assert_nil @auction_ended.find_draft
+    assert_includes @auction_ended.messages, "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{@auction_ended.auction_id}."
+  end
+
   test '#update_order_customer_info' do
     [
       @offer_accepted,

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -507,6 +507,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     end
   end
 
+  test '#create_customer logs errors' do
+    Customer.delete_all
+    Customer.new(ytunnus: @offer_accepted_2.company_id).save(validate: false)
+
+    customer = @offer_accepted_2.create_customer
+
+    message = "Asiakkaan #{customer.nimi} (#{customer.email}) luonti epäonnistui."
+    assert_includes @offer_accepted_2.messages.to_s, message
+  end
+
   test '#update_customer' do
     [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
       assert email.update_customer

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -557,8 +557,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#find_draft logs errors' do
     sales_order_drafts(:huutokauppa_279590).delete
-    exception = assert_raise { @auction_ended.find_draft }
-    assert_equal "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{@auction_ended.auction_id}.", exception.message
+    assert_nil @auction_ended.find_draft
+    assert_includes @auction_ended.messages, "Kesken olevaa myyntitilausta ei löytynyt huutokaupalle #{@auction_ended.auction_id}."
   end
 
   test '#update_order_customer_info' do

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -105,7 +105,7 @@ class HuutokauppaJobTest < ActiveJob::TestCase
     HuutokauppaJob.perform_now(id: incoming_mail.id)
 
     assert_equal 'error', incoming_mail.reload.status
-    assert_equal "undefined method `selite' for nil:NilClass", incoming_mail.reload.status_message
+    assert_includes incoming_mail.reload.status_message, "undefined method `selite' for nil:NilClass"
   end
 
   test 'order is marked as done correctly and delivery type set to nouto when no info about delivery' do

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -127,13 +127,9 @@ class HuutokauppaJobTest < ActiveJob::TestCase
       end
     end
 
-    order = SalesOrder::Order.find_by!(viesti: 270_265)
-
-    assert_equal delivery_methods(:nouto), order.delivery_method
-
     assert_equal 'ok', incoming_mail.reload.status
-    message = "Päivitettiin tilauksen (Tilausnumero: #{order.id}, Huutokauppa: #{order.viesti}) toimitustavaksi Nouto."
-    assert_includes incoming_mail.reload.status_message, message
+    message = 'Merkittiin tilaus'
+    assert_includes incoming_mail.reload.status_message.to_s, message
   end
 
   test 'order delivery info is updated and delivery method set when type is delivery ordered' do

--- a/test/models/incoming_mail_test.rb
+++ b/test/models/incoming_mail_test.rb
@@ -22,4 +22,19 @@ class IncomingMailTest < ActiveSupport::TestCase
     assert_nothing_raised       { incoming_mails(:one).status = :ok    }
     assert_raise(ArgumentError) { incoming_mails(:one).status = :kissa }
   end
+
+  test '#mail' do
+    assert incoming_mails(:one).mail.is_a?(Mail::Message)
+
+    incoming_mails(:one).raw_source = nil
+    incoming_mails(:one).save(validate: false)
+    assert incoming_mails(:one).reload.mail.is_a?(Mail::Message)
+  end
+
+  test '#subject' do
+    assert_nil incoming_mails(:one).subject
+
+    incoming_mails(:one).mail.subject = 'Test subject'
+    assert_equal 'Test subject', incoming_mails(:one).subject
+  end
 end

--- a/test/models/sales_order/row_test.rb
+++ b/test/models/sales_order/row_test.rb
@@ -44,4 +44,10 @@ class SalesOrder::RowTest < ActiveSupport::TestCase
     @one.update_attributes! keratty: 'joe'
     assert_equal 1, @one.order.rows.picked.count
   end
+
+  test '#parent?' do
+    refute @one.parent?
+    @one.perheid = @one.tunnus
+    assert @one.parent?
+  end
 end


### PR DESCRIPTION
* Fill toim and laskutus fields with customer info
* Log failed customer update and create
* Log if order can't be found in find_draft & find_order
* Update delivery type to nouto when processing offer accepted mail
* Log product tuoteno and price when updating and adding products
* Prefix ytunnus with HK
* Add and use Row#parent?
* Find draft if order can't be found in update_order_delivery_info and update_delivery_method_to_itella_economy_16
* Show mail subject in incoming mails index