### PR TITLE
Huutokauppa fixes

### DIFF
--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -45,6 +45,10 @@ class HuutokauppaMail
     customer_info[:name]
   end
 
+  def name
+    company_name || customer_name
+  end
+
   def customer_email
     customer_info[:email]
   end

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -244,9 +244,7 @@ class HuutokauppaMail
   end
 
   def update_order_customer_info
-    return unless (customer_name || company_name) && find_draft
-
-    name = company_name ? company_name : customer_name
+    return unless name && find_draft
 
     find_draft.update!(
       nimi: name,

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -160,7 +160,7 @@ class HuutokauppaMail
   end
 
   def create_customer
-    return unless customer_name
+    return unless name
 
     customer = Customer.new(
       email: customer_email,

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -166,7 +166,7 @@ class HuutokauppaMail
       email: customer_email,
       gsm: customer_phone,
       kauppatapahtuman_luonne: Keyword::NatureOfTransaction.first.selite,
-      nimi: customer_name,
+      nimi: name,
       osoite: customer_address,
       postino: customer_postcode,
       postitp: customer_city,

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -240,10 +240,12 @@ class HuutokauppaMail
   end
 
   def update_order_customer_info
-    return unless customer_name && find_draft
+    return unless (customer_name || company_name) && find_draft
+
+    name = company_name ? company_name : customer_name
 
     find_draft.update!(
-      nimi: customer_name,
+      nimi: name,
       nimitark: '',
       osoite: customer_address,
       postino: customer_postcode,
@@ -252,7 +254,7 @@ class HuutokauppaMail
       email: customer_email,
       ytunnus: company_id || auction_id,
 
-      toim_nimi: customer_name,
+      toim_nimi: name,
       toim_nimitark: '',
       toim_osoite: customer_address,
       toim_postino: customer_postcode,
@@ -262,7 +264,7 @@ class HuutokauppaMail
     )
 
     find_draft.detail.update!(
-      laskutus_nimi: customer_name,
+      laskutus_nimi: name,
       laskutus_nimitark: '',
       laskutus_osoite: customer_address,
       laskutus_postino: customer_postcode,

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -177,6 +177,8 @@ class HuutokauppaMail
       piiri: 1,
     )
 
+    customer.laji = 'H' unless company_name
+
     if customer.save
       @messages << "Asiakas #{customer_message_info(customer)} luotu."
       return customer

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -174,6 +174,7 @@ class HuutokauppaMail
       delivery_method: DeliveryMethod.find_by!(selite: 'Nouto'),
       terms_of_payment: TermsOfPayment.find_by!(rel_pvm: 2),
       chn: 667,
+      piiri: 1,
     )
 
     if customer.save
@@ -195,6 +196,7 @@ class HuutokauppaMail
       osoite: customer_address,
       postino: customer_postcode,
       postitp: customer_city,
+      piiri: 1,
     )
 
     if update_success

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -305,12 +305,13 @@ class HuutokauppaMail
     return unless find_draft
 
     row = find_draft.rows.first
+    qty = row.tilkpl
 
     row.update!(
       alv: auction_vat_percent,
-      hinta: auction_price_without_vat,
-      hinta_alkuperainen: auction_price_without_vat,
-      hinta_valuutassa: auction_price_without_vat,
+      hinta: auction_price_without_vat / qty,
+      hinta_alkuperainen: auction_price_without_vat / qty,
+      hinta_valuutassa: auction_price_without_vat / qty,
       nimitys: auction_title,
       rivihinta: auction_price_without_vat,
       rivihinta_valuutassa: auction_price_without_vat,

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -191,7 +191,7 @@ class HuutokauppaMail
 
     update_success = find_customer.update(
       gsm: customer_phone,
-      nimi: customer_name,
+      nimi: name,
       osoite: customer_address,
       postino: customer_postcode,
       postitp: customer_city,

--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -369,9 +369,9 @@ class HuutokauppaMail
 
     return unless order
 
-    order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Itella Economy 16'))
+    order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Posti Economy 16'))
 
-    @messages << "Päivitettiin tilauksen #{order_message_info(order)} toimitustavaksi Itella Economy 16."
+    @messages << "Päivitettiin tilauksen #{order_message_info(order)} toimitustavaksi Posti Economy 16."
 
     true
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -69,7 +69,6 @@ class Customer < BaseModel
       self.kieli        = 'fi' if kieli.blank?
       self.kolm_maa     = maa if kolm_maa.blank?
       self.lahetetyyppi = Keyword::PackingListType.first.try(:selite) if lahetetyyppi.blank?
-      self.laji         = 'H' if laji.blank?
       self.laskutus_maa = maa if laskutus_maa.blank?
       self.laskutyyppi  = -9 if laskutyyppi.blank?
       self.maa          = 'fi' if maa.blank?

--- a/test/assets/huutokauppa_emails/offer_accepted_3
+++ b/test/assets/huutokauppa_emails/offer_accepted_3
@@ -1,0 +1,69 @@
+Return-path: <bounces@automated.huutokaupat.com>
+Envelope-to: testite@testi.te
+Delivery-date: Sun, 15 May 2016 20:17:54 +0300
+Received: from filter2.hostingservice.fi ([31.217.192.174]:38733)
+    by cloud13.hostingpalvelu.fi with esmtps (TLSv1.2:ECDHE-RSA-AES256-GCM-SHA384:256)
+    (Exim 4.87)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1b1zfq-000kLw-SS; Sun, 15 May 2016 20:17:50 +0300
+Received: from server.huutokaupat.com ([83.150.76.4])
+    by filter2.hostingservice.fi with esmtp (Exim 4.85)
+    (envelope-from <bounces@automated.huutokaupat.com>)
+    id 1b1zfm-0005qv-KT; Sun, 15 May 2016 20:17:47 +0300
+Received: from localhost (unknown [10.10.10.128])
+    by server.huutokaupat.com (Postfix) with ESMTP id 6667420073A;
+    Sun, 15 May 2016 20:17:46 +0300 (EEST)
+From: "Huutokaupat.com" <asiakaspalvelu@huutokaupat.com>
+To: testite@testi.te
+Subject: =?utf-8?Q?Tarjous=20hyv=C3=A4ksytty=20Huutokaupat.com=20?=
+ =?utf-8?Q?nettihuutokauppa:=20kohde=20#298958?=
+Date: Sun, 15 May 2016 20:17:46 +0300
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+MIME-Version: 1.0
+X-Filter-ID: s0sct1PQhAABKnZB5plbIeAyHwHIceqjIqYzluv0NUpuO2tWUqBCEbdShNj29n29hTQlI8BJQNwf
+ dZmIYTr6GnVEJQAYV9ff1+lJ+Sf2nQ3k+GDP+f6xF7XLnlq3j2ne/5FdbgtqnqT56S7k+tyLwZHf
+ WZYD82R/uX1kWNJz4wES3dsoT4fYpUWtq2l6tT6ampYbIWehzfMhBX2xrya8NiYD1ptUVn6ByrDO
+ Wen4bPcvcplYN5zMlHdXzOu7gRr7JZBJUDyXddX3lRgqX8VJ+gZ2Oot2XYq2kcVIzFMQkte6tPHt
+ LyzZCWuI1lWShN2ZvFYRgX+0Ga+wpZneZoLeknD+IIJA3sPCXJmtDrxlA0glf6If6o0H9OmL2MOG
+ CCKu14EZcYQodZ3dtTOBObK8rTtAhvZ+jk3KQHpIxt+LqsM0/26KQQ56kksWPWkuPM4rf31PkeT8
+ B8SvQDphkNQA096XGL3BcCViGF8Ms8HmvxYccBIk1Sag4dKiqCrF8eZZ1QKGh0qWElWVzMt+gDDu
+ PCxbLkMTkueS9eLMwBBrl0DLaj1rrhV9FTOiKy3QCCy0nEDOOfnFvfsNckTY9armW6du7YBkSkRX
+ Tt/+TR/4nZ9cx27wGwS5kLDevm+s6yZpv6YduA8Lx1fCvcudebVC4TVCN2yBNFfEjtFAzcQKhve1
+ /yKwIsn5lhTLVd3ts+3J3753NLZTucowc8mNHroqfN38xsMaJqpQXhTdrZKZ4pxWvhrH/0RI1Ygm
+ C2egZaYwot5OtxkmsUUseoTPSYQjcrcFP/Fxqx7uULDQRB3NLRBaMe5iU7V0whZJxAmzTve1qw+Q
+ Gd5oG5wmjv8l6i8rvQ==
+X-Report-Abuse-To: spam@filter1.hostingservice.fi
+X-SpamExperts-Class: whitelisted
+X-SpamExperts-Evidence: sender
+X-Recommended-Action: accept
+
+<p>=0A    Olette hyv=C3=A4ksyneet tarjouksen seuraavasta kohteesta:=0A</=
+p>=0A=0A<p>=0A    Kohde #298958<br/>=0A    Otsikkokentt=C3=A4: 09.05.-15=
+.05. Kompressorivaunu Ingersoll Rand 7/31, Lahti<br/>=0A    P=C3=A4=C3=
+=A4ttymisaika: Sunnuntai 15.05.2016 klo 19:52<br/>=0A    Huudettu: 2=C2=
+=A0000 EUR<br/>=0A    Alv-osuus: 0 EUR<br/>=0A    Summa: 2=C2=A0000 EUR,=
+ ALV 0 %=0A</p>=0A=0A<p>=0A    Ostajan yhteystiedot:<br/>=0A           =
+ Yritys:<br/>=0A        Testit ky T<br/>=0A        FI23456789<br/>=0A  =
+      Testit ky T<br/>=0A    testitest@testi.tes<br/>=0A            Puhe=
+lin: +012 34 5678901<br/>=0A        Osoite:<br/>=0A    testitest=C3=A4it=
+es 222<br/>=0A    98765 Testi<br/>=0A    Suomi=0A</p>=0A=0A<p>=0A    Myy=
+j=C3=A4n/toimeksisaaneen yhteystiedot:<br/>=0A    Testi Testitest<br />=
+=0AY-tunnus: 1234567-8<br />=0ATest Testites<br />=0Atest.testites@testi=
+.te<br />=0A+555 12 3456789<br />=0A<br />=0ARahti tilaukset<br />=0Ates=
+tit@testi.te<br />=0A<br />=0A<br />=0AIlmoittajan viite: M1965/8<br />=
+=0A<br/>=0A    <br/>=0A    Maksutapa: Verkkopankkimaksu. Pankit: Nordea,=
+ Danske Bank, Osuuspankki, S-pankki, Aktia, Handelsbanken, =C3=85landsba=
+nken, Pop-pankki, S=C3=A4=C3=A4st=C3=B6pankki, Oma S=C3=A4=C3=A4st=C3=B6=
+pankki<br/>=0A    <br/>=0A    Huutokaupan tilana n=C3=A4kyy ilmoituksess=
+a: P=C3=A4=C3=A4ttynyt =E2=80=93 tarjous hyv=C3=A4ksytty.<br/>=0A    <br=
+/>=0A    Kohteen ostajalla on kaksi arkip=C3=A4iv=C3=A4=C3=A4 aikaa suor=
+ittaa kauppahinta Huutokaupat.com palvelua yll=C3=A4pit=C3=A4v=C3=A4n Me=
+zzoforte Oy:n asiakastilille.  Saatte meilt=C3=A4 s=C3=A4hk=C3=B6postill=
+a vahvistuksen toteutuneesta kauppasummasta.<br/>=0A    <br/>=0A    Maks=
+usuorituksen j=C3=A4lkeen huutokaupan tilana n=C3=A4kyy ilmoituksessa: M=
+yyty.<br/>=0A    <br/>=0A    Myyntikohde n=C3=A4kyy myynnin toteuduttua=
+ sivuilla 7 p=C3=A4iv=C3=A4=C3=A4 ja poistuu t=C3=A4m=C3=A4n j=C3=A4lkee=
+n sivuilta automaattisesti.=0A</p>=0A=0A<p>=0A    Yst=C3=A4v=C3=A4llisin=
+ terveisin,<br/>=0AHuutokaupat.com=0A=0A</p>=0A

--- a/test/assets/huutokauppa_emails/offer_automatically_accepted_2
+++ b/test/assets/huutokauppa_emails/offer_automatically_accepted_2
@@ -1,0 +1,77 @@
+Return-path: <bounces@automated.huutokaupat.com>
+Envelope-to: testite@testi.te
+Delivery-date: Sun, 15 May 2016 21:02:23 +0300
+Received: from filter2.hostingservice.fi ([31.217.192.174]:41912)
+	by cloud13.hostingpalvelu.fi with esmtps (TLSv1.2:ECDHE-RSA-AES256-GCM-SHA384:256)
+	(Exim 4.87)
+	(envelope-from <bounces@automated.huutokaupat.com>)
+	id 1b20Mv-000qZB-IL; Sun, 15 May 2016 21:02:21 +0300
+Received: from server.huutokaupat.com ([83.150.76.4])
+	by filter2.hostingservice.fi with esmtp (Exim 4.85)
+	(envelope-from <bounces@automated.huutokaupat.com>)
+	id 1b20Mr-0000YD-SO; Sun, 15 May 2016 21:02:18 +0300
+Received: from localhost (unknown [10.10.10.130])
+	by server.huutokaupat.com (Postfix) with ESMTP id 61A1120267C;
+	Sun, 15 May 2016 21:02:17 +0300 (EEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=huutokaupat.com;
+	s=default; t=1463335337;
+	bh=GsVoYcncZoekB596NMJXOxrzk1gtWWWeFMPl88qTo80=;
+	h=From:To:Subject:Date;
+	b=pHhLRYRHf+TjOPCRSDHFFukF8FwaPYFE6SbfpSWdYK48o7iIbuPWRJR0cWqSBGOsi
+	 +dYxmi6zj00EbT3FN0AKuEFKsMSDy7a2MWJKcyNk3zF3DhZxM1PCE5cvFEX3EqhUXW
+	 xAvI1RjnNEVk3viEtcj/oqFW7MU2QrCSOBWrbTYY=
+From: "Huutokaupat.com" <asiakaspalvelu@huutokaupat.com>
+To: testite@testi.te
+Subject: =?utf-8?Q?Tarjous=20automaattisesti=20hyv=C3=A4ksytty=20?=
+ =?utf-8?Q?Huutokaupat.com=20nettihuutokauppa:=20kohde=20#294627?=
+Date: Sun, 15 May 2016 21:02:17 +0300
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+MIME-Version: 1.0
+Message-Id: <20160515180217.61A1120267C@server.huutokaupat.com>
+X-Filter-ID: s0sct1PQhAABKnZB5plbIeAyHwHIceqjIqYzluv0NUpuO2tWUqBCEbdShNj29n29hTQlI8BJQNwf
+ dZmIYTr6GnVEJQAYV9ff1+lJ+Sf2nQ3k+GDP+f6xF7XLnlq3j2ne/5FdbgtqnqT56S7k+tyLwZHf
+ WZYD82R/uX1kWNJz4wES3dsoT4fYpUWtq2l6tT6ampYbIWehzfMhBX2xrya8NiYD1ptUVn6ByrDO
+ Wen4bPcvcplYN5zMlHdXzOu7gRr7JZBJUDyXddX3lRgqX8VJ+tAeq+cds6nJlNErvZtFoqBG5Tpk
+ D/Jv7PkKJQMLl7iniwQzKw+6v3CaIMG6s7LqJAIIBVgPWFQrNNt4skZxEXKQm4E4p26nSSkPphfX
+ rBhTiG4XwpsXfeh5n1ZI7qO6rgm3sj9lmtbo8r2I2S7vXK4xdl4Rx1zKKGrFnQlTtN9Me+rrxbVY
+ RI5qM5mkwzDs9idlTZ/1FHjgq2v1uRnTIQkzjyjL/QuDtdf6sFzW2z/xrZ1imVBgEPlWeT9NV68R
+ zTGyrcyC2vCRmxz47BFeriZoD7bAeKsWl/oNzWdtNsPTrUXX5D+Zk7NvU6DQewiNCincCmK8uaqK
+ pmdh0n2Qm1Vxy/ihLCT5uxnmHhGGy2O3GwTuewy/HmZZ5Q1Q/X20UmtnqtxYC4A8Mpq5s+pEiB7R
+ rozQuRVmTz0MvEjBP3L2CCqB9MF1QnIcvR4Oc30Set++dzS2U7nKMHPJjR66Knzy8PsbvOGQC8Rk
+ xXXi70l4QCjD5CFhDgWZDuq0TejmL1C6yAg7PQlNtgw29ArPlaU=
+X-Report-Abuse-To: spam@filter1.hostingservice.fi
+Authentication-Results: hostingservice.fi; dkim=pass header.i=huutokaupat.com
+X-SpamExperts-Class: whitelisted
+X-SpamExperts-Evidence: sender
+X-Recommended-Action: accept
+
+<p>=0A    Kohteen korkein tarjous on automaattisesti hyv=C3=A4ksytty:=0A=
+</p>=0A=0A<p>=0A    Kohde #294627<br/>=0A    Otsikkokentt=C3=A4: 10.05.-=
+15.05. Tasapainoskootteri, v=C3=A4ri punainen, UUSI, Lahti<br/>=0A    P=
+=C3=A4=C3=A4ttymisaika: Sunnuntai 15.05.2016 klo 21:00<br/>=0A    Huudet=
+tu: 225 EUR<br/>=0A    Hintavaraus: 0,00 EUR<br/>=0A    Alv-osuus: 54 EU=
+R<br/>=0A    Summa: 279 EUR, ALV 24 %=0A</p>=0A=0A<p>=0A    Ostajan yhte=
+ystiedot:<br/>=0A            Yritys:<br/>=0A        TE-Testitest Oy<br/>=
+=0A        1234567-8<br/>=0A        Test testi testit Testites<br/>=0A =
+   test@te-testitest.te<br/>=0A            Puhelin: +123 45 6789012<br/>=
+=0A        Osoite:<br/>=0A    Testitestit 1 k<br/>=0A    12345 Testite<b=
+r/>=0A    Suomi=0A</p>=0A=0A<p>=0A    Myyj=C3=A4n/toimeksisaaneen yhteys=
+tiedot:<br/>=0A    Testi Testitest<br />=0AY-tunnus: 1234567-8<br />=0AR=
+ahti tilaukset<br />=0Atestit@testi.te<br />=0A<br />=0A<br />=0AIlmoitt=
+ajan viite: X1P-908<br />=0A<br/>=0A    <br/>=0A    Maksutapa: Verkkopan=
+kkimaksu. Pankit: Nordea, Danske Bank, Osuuspankki, S-pankki, Aktia, Han=
+delsbanken, =C3=85landsbanken, Pop-pankki, S=C3=A4=C3=A4st=C3=B6pankki,=
+ Oma S=C3=A4=C3=A4st=C3=B6pankki<br/>=0A    <br/>=0A    Huutokaupan tila=
+na n=C3=A4kyy ilmoituksessa: P=C3=A4=C3=A4ttynyt =E2=80=93 tarjous hyv=
+=C3=A4ksytty.<br/>=0A    <br/>=0A    Kohteen ostajalla on kaksi arkip=C3=
+=A4iv=C3=A4=C3=A4 aikaa suorittaa kauppahinta Huutokaupat.com palvelua y=
+ll=C3=A4pit=C3=A4v=C3=A4n Mezzoforte Oy:n asiakastilille.  Saatte meilt=
+=C3=A4 s=C3=A4hk=C3=B6postilla vahvistuksen toteutuneesta kauppasummasta=
+.<br/>=0A    <br/>=0A    Maksusuorituksen j=C3=A4lkeen huutokaupan tilan=
+a n=C3=A4kyy ilmoituksessa: Myyty.<br/>=0A    <br/>=0A    Myyntikohde n=
+=C3=A4kyy myynnin toteuduttua sivuilla 7 p=C3=A4iv=C3=A4=C3=A4 ja poistu=
+u t=C3=A4m=C3=A4n j=C3=A4lkeen sivuilta automaattisesti.=0A</p>=0A=0A<p>=
+=0A    Yst=C3=A4v=C3=A4llisin terveisin,<br/>=0AHuutokaupat.com=0A=0A</p=
+>=0A

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -695,13 +695,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     ].each do |email|
       assert email.update_order_product_info
 
-      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.hinta
-      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.hinta_alkuperainen
-      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.hinta_valuutassa
-      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.rivihinta
-      assert_equal email.auction_price_without_vat, email.find_draft.rows.first.rivihinta_valuutassa
-      assert_equal email.auction_title,             email.find_draft.rows.first.nimitys
-      assert_equal email.auction_vat_percent,       email.find_draft.rows.first.alv
+      row = email.find_draft.rows.first
+      qty = row.tilkpl
+
+      assert_equal email.auction_price_without_vat / qty, row.hinta
+      assert_equal email.auction_price_without_vat / qty, row.hinta_alkuperainen
+      assert_equal email.auction_price_without_vat / qty, row.hinta_valuutassa
+      assert_equal email.auction_price_without_vat,       row.rivihinta
+      assert_equal email.auction_price_without_vat,       row.rivihinta_valuutassa
+      assert_equal email.auction_title,                   row.nimitys
+      assert_equal email.auction_vat_percent,             row.alv
 
       message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) tuotetiedot"
       assert_includes email.messages.to_s, message

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -22,18 +22,19 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     Current.user = users(:bob)
 
     # setup all emails
-    @auction_ended                = HuutokauppaMail.new huutokauppa_email(:auction_ended_1)
-    @bidder_picks_up              = HuutokauppaMail.new huutokauppa_email(:bidder_picks_up_1)
-    @delivery_offer_request       = HuutokauppaMail.new huutokauppa_email(:delivery_offer_request_1)
-    @delivery_ordered             = HuutokauppaMail.new huutokauppa_email(:delivery_ordered_1)
-    @invalid_customer_info        = HuutokauppaMail.new huutokauppa_email(:invalid_customer_info)
-    @offer_accepted               = HuutokauppaMail.new huutokauppa_email(:offer_accepted_1)
-    @offer_accepted_2             = HuutokauppaMail.new huutokauppa_email(:offer_accepted_2)
-    @offer_automatically_accepted = HuutokauppaMail.new huutokauppa_email(:offer_automatically_accepted_1)
-    @offer_declined               = HuutokauppaMail.new huutokauppa_email(:offer_declined_1)
-    @purchase_price_paid          = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_1)
-    @purchase_price_paid_2        = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_2)
-    @purchase_price_paid_3        = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_3)
+    @auction_ended                  = HuutokauppaMail.new huutokauppa_email(:auction_ended_1)
+    @bidder_picks_up                = HuutokauppaMail.new huutokauppa_email(:bidder_picks_up_1)
+    @delivery_offer_request         = HuutokauppaMail.new huutokauppa_email(:delivery_offer_request_1)
+    @delivery_ordered               = HuutokauppaMail.new huutokauppa_email(:delivery_ordered_1)
+    @invalid_customer_info          = HuutokauppaMail.new huutokauppa_email(:invalid_customer_info)
+    @offer_accepted                 = HuutokauppaMail.new huutokauppa_email(:offer_accepted_1)
+    @offer_accepted_2               = HuutokauppaMail.new huutokauppa_email(:offer_accepted_2)
+    @offer_automatically_accepted   = HuutokauppaMail.new huutokauppa_email(:offer_automatically_accepted_1)
+    @offer_automatically_accepted_2 = HuutokauppaMail.new huutokauppa_email(:offer_automatically_accepted_2)
+    @offer_declined                 = HuutokauppaMail.new huutokauppa_email(:offer_declined_1)
+    @purchase_price_paid            = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_1)
+    @purchase_price_paid_2          = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_2)
+    @purchase_price_paid_3          = HuutokauppaMail.new huutokauppa_email(:purchase_price_paid_3)
 
     @emails_without_customer_info = [
       @auction_ended,
@@ -49,6 +50,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_accepted,
       @offer_accepted_2,
       @offer_automatically_accepted,
+      @offer_automatically_accepted_2,
       @offer_declined,
       @purchase_price_paid,
       @purchase_price_paid_2,
@@ -87,6 +89,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal :offer_accepted,               @offer_accepted.type
     assert_equal :offer_accepted,               @offer_accepted_2.type
     assert_equal :offer_automatically_accepted, @offer_automatically_accepted.type
+    assert_equal :offer_automatically_accepted, @offer_automatically_accepted_2.type
     assert_equal :offer_declined,               @offer_declined.type
     assert_equal :purchase_price_paid,          @purchase_price_paid.type
     assert_equal :purchase_price_paid,          @purchase_price_paid_2.type
@@ -94,7 +97,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#company_name' do
-    assert_equal 'Testites Oy', @offer_accepted_2.company_name
+    assert_equal 'Testites Oy',     @offer_accepted_2.company_name
+    assert_equal 'TE-Testitest Oy', @offer_automatically_accepted_2.company_name
 
     assert_nil @auction_ended.company_name
     assert_nil @bidder_picks_up.company_name
@@ -111,6 +115,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#company_id' do
     assert_equal 'FI01234567', @offer_accepted_2.company_id
+    assert_equal '1234567-8',  @offer_automatically_accepted_2.company_id
 
     assert_nil @auction_ended.company_id
     assert_nil @bidder_picks_up.company_id
@@ -126,12 +131,13 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#customer_name' do
-    assert_equal 'Testi Testit Testitestit', @offer_accepted.customer_name
-    assert_equal 'Testi Testiä',             @offer_accepted_2.customer_name
-    assert_equal 'Test-testi Testite',       @offer_automatically_accepted.customer_name
-    assert_equal 'Test-testi Testite',       @purchase_price_paid.customer_name
-    assert_equal 'Test testit Testi',        @purchase_price_paid_2.customer_name
-    assert_equal 'Test test testi Testite',  @purchase_price_paid_3.customer_name
+    assert_equal 'Testi Testit Testitestit',   @offer_accepted.customer_name
+    assert_equal 'Testi Testiä',               @offer_accepted_2.customer_name
+    assert_equal 'Test-testi Testite',         @offer_automatically_accepted.customer_name
+    assert_equal 'Test testi testit Testites', @offer_automatically_accepted_2.customer_name
+    assert_equal 'Test-testi Testite',         @purchase_price_paid.customer_name
+    assert_equal 'Test testit Testi',          @purchase_price_paid_2.customer_name
+    assert_equal 'Test test testi Testite',    @purchase_price_paid_3.customer_name
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_name
@@ -146,6 +152,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 'testit@testi.tes',          @offer_accepted.customer_email
     assert_equal 'testi.testit@testit.te',    @offer_accepted_2.customer_email
     assert_equal 'te.testite@testi.tes',      @offer_automatically_accepted.customer_email
+    assert_equal 'test@te-testitest.te',      @offer_automatically_accepted_2.customer_email
     assert_equal 'te.testite@testi.tes',      @purchase_price_paid.customer_email
     assert_equal 'test.testi@testitestit.fi', @purchase_price_paid_2.customer_email
     assert_equal 'testite@testite.tes',       @purchase_price_paid_3.customer_email
@@ -159,6 +166,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '+123 45 6789012', @offer_accepted.customer_phone
     assert_equal '+123 45 6789012', @offer_accepted_2.customer_phone
     assert_equal '+123 45 6789012', @offer_automatically_accepted.customer_phone
+    assert_equal '+123 45 6789012', @offer_automatically_accepted_2.customer_phone
     assert_equal '+123 45 6789012', @purchase_price_paid.customer_phone
     assert_equal '+123 45 6789012', @purchase_price_paid_2.customer_phone
     assert_equal '+123 45 6789012', @purchase_price_paid_3.customer_phone
@@ -172,6 +180,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 'testitestit 12',    @offer_accepted.customer_address
     assert_equal 'Testites 52',       @offer_accepted_2.customer_address
     assert_equal 'Testitesti 123',    @offer_automatically_accepted.customer_address
+    assert_equal 'Testitestit 1 k',   @offer_automatically_accepted_2.customer_address
     assert_equal 'Testitesti 123',    @purchase_price_paid.customer_address
     assert_equal 'Testitest 21',      @purchase_price_paid_2.customer_address
     assert_equal 'Testiteäki 12 A 1', @purchase_price_paid_3.customer_address
@@ -185,6 +194,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '12345', @offer_accepted.customer_postcode
     assert_equal '12345', @offer_accepted_2.customer_postcode
     assert_equal '23456', @offer_automatically_accepted.customer_postcode
+    assert_equal '12345', @offer_automatically_accepted_2.customer_postcode
     assert_equal '12345', @purchase_price_paid.customer_postcode
     assert_equal '12345', @purchase_price_paid_2.customer_postcode
     assert_equal '12345', @purchase_price_paid_3.customer_postcode
@@ -198,6 +208,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 'Testi',      @offer_accepted.customer_city
     assert_equal 'Testätes',   @offer_accepted_2.customer_city
     assert_equal 'Testitesti', @offer_automatically_accepted.customer_city
+    assert_equal 'Testite',    @offer_automatically_accepted_2.customer_city
     assert_equal 'Testitesti', @purchase_price_paid.customer_city
     assert_equal 'Testi',      @purchase_price_paid_2.customer_city
     assert_equal 'testite',    @purchase_price_paid_3.customer_city
@@ -211,6 +222,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 'Suomi', @offer_accepted.customer_country
     assert_equal 'Suomi', @offer_accepted_2.customer_country
     assert_equal 'Suomi', @offer_automatically_accepted.customer_country
+    assert_equal 'Suomi', @offer_automatically_accepted_2.customer_country
     assert_equal 'Suomi', @purchase_price_paid.customer_country
     assert_equal 'Suomi', @purchase_price_paid_2.customer_country
     assert_equal 'Suomi', @purchase_price_paid_3.customer_country
@@ -285,6 +297,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @offer_accepted.delivery_price_without_vat
     assert_nil @offer_accepted_2.delivery_price_without_vat
     assert_nil @offer_automatically_accepted.delivery_price_without_vat
+    assert_nil @offer_automatically_accepted_2.delivery_price_without_vat
     assert_nil @offer_declined.delivery_price_without_vat
     assert_nil @purchase_price_paid.delivery_price_without_vat
   end
@@ -300,6 +313,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @offer_accepted.delivery_price_with_vat
     assert_nil @offer_accepted_2.delivery_price_with_vat
     assert_nil @offer_automatically_accepted.delivery_price_with_vat
+    assert_nil @offer_automatically_accepted_2.delivery_price_with_vat
     assert_nil @offer_declined.delivery_price_with_vat
     assert_nil @purchase_price_paid.delivery_price_with_vat
   end
@@ -315,6 +329,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @offer_accepted.delivery_vat_percent
     assert_nil @offer_accepted_2.delivery_vat_percent
     assert_nil @offer_automatically_accepted.delivery_vat_percent
+    assert_nil @offer_automatically_accepted_2.delivery_vat_percent
     assert_nil @offer_declined.delivery_vat_percent
     assert_nil @purchase_price_paid.delivery_vat_percent
   end
@@ -330,6 +345,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @offer_accepted.delivery_vat_amount
     assert_nil @offer_accepted_2.delivery_vat_amount
     assert_nil @offer_automatically_accepted.delivery_vat_amount
+    assert_nil @offer_automatically_accepted_2.delivery_vat_amount
     assert_nil @offer_declined.delivery_vat_amount
     assert_nil @purchase_price_paid.delivery_vat_amount
   end
@@ -342,6 +358,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 824.6,      @offer_accepted.total_price_with_vat
     assert_equal 10_664.0,   @offer_accepted_2.total_price_with_vat
     assert_equal 372.0,      @offer_automatically_accepted.total_price_with_vat
+    assert_equal 279.0,      @offer_automatically_accepted_2.total_price_with_vat
     assert_equal 62.0,       @offer_declined.total_price_with_vat
     assert_equal 372.0,      @purchase_price_paid.total_price_with_vat
     assert_equal 248.0,      @purchase_price_paid_2.total_price_with_vat
@@ -356,6 +373,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '277075', @offer_accepted.auction_id
     assert_equal '293363', @offer_accepted_2.auction_id
     assert_equal '270265', @offer_automatically_accepted.auction_id
+    assert_equal '294627', @offer_automatically_accepted_2.auction_id
     assert_equal '277687', @offer_declined.auction_id
     assert_equal '270265', @purchase_price_paid.auction_id
     assert_equal '287912', @purchase_price_paid_2.auction_id
@@ -384,6 +402,9 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     title = 'Auton keinunostin, 1500 kg, UUSI, Lahti'
     assert_equal title, @offer_automatically_accepted.auction_title
 
+    title = 'Tasapainoskootteri, väri punainen, UUSI, Lahti'
+    assert_equal title, @offer_automatically_accepted_2.auction_title
+
     title = 'Vaijerikeloja lavalla, Lahti'
     assert_equal title, @offer_declined.auction_title
 
@@ -405,6 +426,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal "2016-03-25 20:10".to_time, @offer_accepted.auction_closing_date
     assert_equal "2016-05-01 20:25".to_time, @offer_accepted_2.auction_closing_date
     assert_equal "2016-03-25 20:20".to_time, @offer_automatically_accepted.auction_closing_date
+    assert_equal "2016-05-15 21:00".to_time, @offer_automatically_accepted_2.auction_closing_date
     assert_equal "2016-03-25 19:40".to_time, @offer_declined.auction_closing_date
     assert_equal "2016-03-25 20:20".to_time, @purchase_price_paid.auction_closing_date
     assert_equal "2016-04-23 19:40".to_time, @purchase_price_paid_2.auction_closing_date
@@ -419,6 +441,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 665,  @offer_accepted.auction_price_without_vat
     assert_equal 8600, @offer_accepted_2.auction_price_without_vat
     assert_equal 300,  @offer_automatically_accepted.auction_price_without_vat
+    assert_equal 225,  @offer_automatically_accepted_2.auction_price_without_vat
     assert_equal 50,   @offer_declined.auction_price_without_vat
     assert_equal 300,  @purchase_price_paid.auction_price_without_vat
     assert_equal 200,  @purchase_price_paid_2.auction_price_without_vat
@@ -433,6 +456,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 824.6,     @offer_accepted.auction_price_with_vat
     assert_equal 10_664.0,  @offer_accepted_2.auction_price_with_vat
     assert_equal 372.0,     @offer_automatically_accepted.auction_price_with_vat
+    assert_equal 279.0,     @offer_automatically_accepted_2.auction_price_with_vat
     assert_equal 62.0,      @offer_declined.auction_price_with_vat
     assert_equal 372.0,     @purchase_price_paid.auction_price_with_vat
     assert_equal 248.0,     @purchase_price_paid_2.auction_price_with_vat
@@ -447,6 +471,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 24, @offer_accepted.auction_vat_percent
     assert_equal 24, @offer_accepted_2.auction_vat_percent
     assert_equal 24, @offer_automatically_accepted.auction_vat_percent
+    assert_equal 24, @offer_automatically_accepted_2.auction_vat_percent
     assert_equal 24, @offer_declined.auction_vat_percent
     assert_equal 24, @purchase_price_paid.auction_vat_percent
     assert_equal 24, @purchase_price_paid_2.auction_vat_percent
@@ -461,6 +486,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 159.6,  @offer_accepted.auction_vat_amount
     assert_equal 2064.0, @offer_accepted_2.auction_vat_amount
     assert_equal 72.0,   @offer_automatically_accepted.auction_vat_amount
+    assert_equal 54.0,   @offer_automatically_accepted_2.auction_vat_amount
     assert_equal 12.0,   @offer_declined.auction_vat_amount
     assert_equal 72.0,   @purchase_price_paid.auction_vat_amount
     assert_equal 48.0,   @purchase_price_paid_2.auction_vat_amount
@@ -473,6 +499,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal customers(:huutokauppa_customer_2), @purchase_price_paid.find_customer
 
     assert_nil @offer_accepted_2.find_customer
+    assert_nil @offer_automatically_accepted_2.find_customer
     assert_nil @purchase_price_paid_2.find_customer
     assert_nil @purchase_price_paid_3.find_customer
 
@@ -486,6 +513,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_accepted,
       @offer_accepted_2,
       @offer_automatically_accepted,
+      @offer_automatically_accepted_2,
       @purchase_price_paid,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
@@ -554,6 +582,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal sales_order_drafts(:huutokauppa_277075), @offer_accepted.find_draft
     assert_equal sales_order_drafts(:huutokauppa_293363), @offer_accepted_2.find_draft
     assert_equal sales_order_drafts(:huutokauppa_270265), @offer_automatically_accepted.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_294627), @offer_automatically_accepted_2.find_draft
     assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_draft
     assert_equal sales_order_drafts(:huutokauppa_270265), @purchase_price_paid.find_draft
     assert_equal sales_order_drafts(:huutokauppa_287912), @purchase_price_paid_2.find_draft
@@ -571,6 +600,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_accepted,
       @offer_accepted_2,
       @offer_automatically_accepted,
+      @offer_automatically_accepted_2,
       @purchase_price_paid,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
@@ -646,6 +676,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_accepted,
       @offer_accepted_2,
       @offer_automatically_accepted,
+      @offer_automatically_accepted_2,
       @offer_declined,
       @purchase_price_paid,
       @purchase_price_paid_2,
@@ -688,6 +719,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         @offer_accepted,
         @offer_accepted_2,
         @offer_automatically_accepted,
+        @offer_automatically_accepted_2,
         @purchase_price_paid,
         @purchase_price_paid_2,
         @purchase_price_paid_3,
@@ -736,6 +768,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_accepted,
       @offer_accepted_2,
       @offer_automatically_accepted,
+      @offer_automatically_accepted_2,
       @offer_declined,
       @purchase_price_paid,
       @purchase_price_paid_2,
@@ -757,6 +790,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @offer_accepted,
       @offer_accepted_2,
       @offer_automatically_accepted,
+      @offer_automatically_accepted_2,
       @offer_declined,
       @purchase_price_paid,
       @purchase_price_paid_2,
@@ -847,6 +881,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
     [
       @offer_accepted_2,
+      @offer_automatically_accepted_2,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
     ].each do |email|

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -523,6 +523,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_difference 'Customer.count' do
         email.create_customer
 
+        assert_equal email.name,                       Customer.last.nimi
         assert_equal delivery_methods(:nouto),         Customer.last.delivery_method
         assert_equal terms_of_payments(:two_days_net), Customer.last.terms_of_payment
         assert_equal '667',                            Customer.last.chn

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -607,7 +607,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     ].each do |email|
       assert email.update_order_customer_info
 
-      assert_equal email.customer_name,     email.find_draft.nimi
+      if email.company_name
+        assert_equal email.company_name, email.find_draft.nimi
+        assert_equal email.company_name, email.find_draft.toim_nimi
+        assert_equal email.company_name, email.find_draft.laskutus_nimi
+      else
+        assert_equal email.customer_name, email.find_draft.nimi
+        assert_equal email.customer_name, email.find_draft.toim_nimi
+        assert_equal email.customer_name, email.find_draft.laskutus_nimi
+      end
+
       assert_empty                          email.find_draft.nimitark
       assert_equal email.customer_address,  email.find_draft.osoite
       assert_empty                          email.find_draft.osoitetark
@@ -616,7 +625,6 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_equal email.customer_phone,    email.find_draft.puh
       assert_equal email.customer_email,    email.find_draft.email
 
-      assert_equal email.customer_name,     email.find_draft.toim_nimi
       assert_empty                          email.find_draft.toim_nimitark
       assert_equal email.customer_address,  email.find_draft.toim_osoite
       assert_equal email.customer_postcode, email.find_draft.toim_postino
@@ -624,7 +632,6 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_equal email.customer_phone,    email.find_draft.toim_puh
       assert_equal email.customer_email,    email.find_draft.toim_email
 
-      assert_equal email.customer_name,     email.find_draft.laskutus_nimi
       assert_empty                          email.find_draft.laskutus_nimitark
       assert_equal email.customer_address,  email.find_draft.laskutus_osoite
       assert_equal email.customer_postcode, email.find_draft.laskutus_postino

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -527,6 +527,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
         assert_equal delivery_methods(:nouto),         Customer.last.delivery_method
         assert_equal terms_of_payments(:two_days_net), Customer.last.terms_of_payment
         assert_equal '667',                            Customer.last.chn
+        assert_equal '1',                              Customer.last.piiri
 
         assert_includes email.messages, "Asiakas #{Customer.last.nimi} (#{Customer.last.email}) luotu."
       end
@@ -554,6 +555,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#update_customer' do
     [@offer_accepted, @offer_automatically_accepted, @purchase_price_paid].each do |email|
       assert email.update_customer
+
+      assert_equal '1', email.find_customer.piiri
 
       assert_includes email.messages, "Asiakas #{email.find_customer.nimi} (#{email.find_customer.email}) päivitetty."
     end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -523,6 +523,12 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       assert_difference 'Customer.count' do
         email.create_customer
 
+        if email.company_name
+          assert_empty Customer.last.laji
+        else
+          assert_equal 'H', Customer.last.laji
+        end
+
         assert_equal email.name,                       Customer.last.nimi
         assert_equal delivery_methods(:nouto),         Customer.last.delivery_method
         assert_equal terms_of_payments(:two_days_net), Customer.last.terms_of_payment

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -901,4 +901,14 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test '#name' do
+    assert_equal 'Testi Testit Testitestit', @offer_accepted.name
+    assert_equal 'Testites Oy',              @offer_accepted_2.name
+    assert_equal 'Test-testi Testite',       @offer_automatically_accepted.name
+    assert_equal 'TE-Testitest Oy',          @offer_automatically_accepted_2.name
+    assert_equal 'Test-testi Testite',       @purchase_price_paid.name
+    assert_equal 'Test testit Testi',        @purchase_price_paid_2.name
+    assert_equal 'Test test testi Testite',  @purchase_price_paid_3.name
+  end
 end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -830,8 +830,8 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
       email.update_delivery_method_to_itella_economy_16
 
-      assert_equal delivery_methods(:itella_economy_16), email.find_order.delivery_method
-      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_order.id}, Huutokauppa: #{email.auction_id}) toimitustavaksi Itella Economy 16."
+      assert_equal delivery_methods(:posti_economy_16), email.find_order.delivery_method
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_order.id}, Huutokauppa: #{email.auction_id}) toimitustavaksi Posti Economy 16."
       assert_includes email.messages, message
     end
   end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -29,6 +29,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     @invalid_customer_info          = HuutokauppaMail.new huutokauppa_email(:invalid_customer_info)
     @offer_accepted                 = HuutokauppaMail.new huutokauppa_email(:offer_accepted_1)
     @offer_accepted_2               = HuutokauppaMail.new huutokauppa_email(:offer_accepted_2)
+    @offer_accepted_3               = HuutokauppaMail.new huutokauppa_email(:offer_accepted_3)
     @offer_automatically_accepted   = HuutokauppaMail.new huutokauppa_email(:offer_automatically_accepted_1)
     @offer_automatically_accepted_2 = HuutokauppaMail.new huutokauppa_email(:offer_automatically_accepted_2)
     @offer_declined                 = HuutokauppaMail.new huutokauppa_email(:offer_declined_1)
@@ -49,6 +50,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @bidder_picks_up,
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_automatically_accepted,
       @offer_automatically_accepted_2,
       @offer_declined,
@@ -88,6 +90,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal :offer_accepted,               @invalid_customer_info.type
     assert_equal :offer_accepted,               @offer_accepted.type
     assert_equal :offer_accepted,               @offer_accepted_2.type
+    assert_equal :offer_accepted,               @offer_accepted_3.type
     assert_equal :offer_automatically_accepted, @offer_automatically_accepted.type
     assert_equal :offer_automatically_accepted, @offer_automatically_accepted_2.type
     assert_equal :offer_declined,               @offer_declined.type
@@ -98,6 +101,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#company_name' do
     assert_equal 'Testites Oy',     @offer_accepted_2.company_name
+    assert_equal 'Testit ky T',     @offer_accepted_3.company_name
     assert_equal 'TE-Testitest Oy', @offer_automatically_accepted_2.company_name
 
     assert_nil @auction_ended.company_name
@@ -115,6 +119,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#company_id' do
     assert_equal 'FI01234567', @offer_accepted_2.company_id
+    assert_equal 'FI23456789', @offer_accepted_3.company_id
     assert_equal '1234567-8',  @offer_automatically_accepted_2.company_id
 
     assert_nil @auction_ended.company_id
@@ -133,6 +138,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#customer_name' do
     assert_equal 'Testi Testit Testitestit',   @offer_accepted.customer_name
     assert_equal 'Testi Testiä',               @offer_accepted_2.customer_name
+    assert_equal 'Testit ky T',                @offer_accepted_3.customer_name
     assert_equal 'Test-testi Testite',         @offer_automatically_accepted.customer_name
     assert_equal 'Test testi testit Testites', @offer_automatically_accepted_2.customer_name
     assert_equal 'Test-testi Testite',         @purchase_price_paid.customer_name
@@ -151,6 +157,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#customer_email' do
     assert_equal 'testit@testi.tes',          @offer_accepted.customer_email
     assert_equal 'testi.testit@testit.te',    @offer_accepted_2.customer_email
+    assert_equal 'testitest@testi.tes',       @offer_accepted_3.customer_email
     assert_equal 'te.testite@testi.tes',      @offer_automatically_accepted.customer_email
     assert_equal 'test@te-testitest.te',      @offer_automatically_accepted_2.customer_email
     assert_equal 'te.testite@testi.tes',      @purchase_price_paid.customer_email
@@ -165,6 +172,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#customer_phone' do
     assert_equal '+123 45 6789012', @offer_accepted.customer_phone
     assert_equal '+123 45 6789012', @offer_accepted_2.customer_phone
+    assert_equal '+012 34 5678901', @offer_accepted_3.customer_phone
     assert_equal '+123 45 6789012', @offer_automatically_accepted.customer_phone
     assert_equal '+123 45 6789012', @offer_automatically_accepted_2.customer_phone
     assert_equal '+123 45 6789012', @purchase_price_paid.customer_phone
@@ -177,13 +185,14 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   end
 
   test '#customer_address' do
-    assert_equal 'testitestit 12',    @offer_accepted.customer_address
-    assert_equal 'Testites 52',       @offer_accepted_2.customer_address
-    assert_equal 'Testitesti 123',    @offer_automatically_accepted.customer_address
-    assert_equal 'Testitestit 1 k',   @offer_automatically_accepted_2.customer_address
-    assert_equal 'Testitesti 123',    @purchase_price_paid.customer_address
-    assert_equal 'Testitest 21',      @purchase_price_paid_2.customer_address
-    assert_equal 'Testiteäki 12 A 1', @purchase_price_paid_3.customer_address
+    assert_equal 'testitestit 12',     @offer_accepted.customer_address
+    assert_equal 'Testites 52',        @offer_accepted_2.customer_address
+    assert_equal 'testitestäites 222', @offer_accepted_3.customer_address
+    assert_equal 'Testitesti 123',     @offer_automatically_accepted.customer_address
+    assert_equal 'Testitestit 1 k',    @offer_automatically_accepted_2.customer_address
+    assert_equal 'Testitesti 123',     @purchase_price_paid.customer_address
+    assert_equal 'Testitest 21',       @purchase_price_paid_2.customer_address
+    assert_equal 'Testiteäki 12 A 1',  @purchase_price_paid_3.customer_address
 
     @emails_without_customer_info.each do |mail|
       assert_nil mail.customer_address
@@ -193,6 +202,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#customer_postcode' do
     assert_equal '12345', @offer_accepted.customer_postcode
     assert_equal '12345', @offer_accepted_2.customer_postcode
+    assert_equal '98765', @offer_accepted_3.customer_postcode
     assert_equal '23456', @offer_automatically_accepted.customer_postcode
     assert_equal '12345', @offer_automatically_accepted_2.customer_postcode
     assert_equal '12345', @purchase_price_paid.customer_postcode
@@ -207,6 +217,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#customer_city' do
     assert_equal 'Testi',      @offer_accepted.customer_city
     assert_equal 'Testätes',   @offer_accepted_2.customer_city
+    assert_equal 'Testi',      @offer_accepted_3.customer_city
     assert_equal 'Testitesti', @offer_automatically_accepted.customer_city
     assert_equal 'Testite',    @offer_automatically_accepted_2.customer_city
     assert_equal 'Testitesti', @purchase_price_paid.customer_city
@@ -221,6 +232,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#customer_country' do
     assert_equal 'Suomi', @offer_accepted.customer_country
     assert_equal 'Suomi', @offer_accepted_2.customer_country
+    assert_equal 'Suomi', @offer_accepted_3.customer_country
     assert_equal 'Suomi', @offer_automatically_accepted.customer_country
     assert_equal 'Suomi', @offer_automatically_accepted_2.customer_country
     assert_equal 'Suomi', @purchase_price_paid.customer_country
@@ -296,6 +308,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @delivery_offer_request.delivery_price_without_vat
     assert_nil @offer_accepted.delivery_price_without_vat
     assert_nil @offer_accepted_2.delivery_price_without_vat
+    assert_nil @offer_accepted_3.delivery_price_without_vat
     assert_nil @offer_automatically_accepted.delivery_price_without_vat
     assert_nil @offer_automatically_accepted_2.delivery_price_without_vat
     assert_nil @offer_declined.delivery_price_without_vat
@@ -312,6 +325,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @delivery_offer_request.delivery_price_with_vat
     assert_nil @offer_accepted.delivery_price_with_vat
     assert_nil @offer_accepted_2.delivery_price_with_vat
+    assert_nil @offer_accepted_3.delivery_price_with_vat
     assert_nil @offer_automatically_accepted.delivery_price_with_vat
     assert_nil @offer_automatically_accepted_2.delivery_price_with_vat
     assert_nil @offer_declined.delivery_price_with_vat
@@ -328,6 +342,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @delivery_offer_request.delivery_vat_percent
     assert_nil @offer_accepted.delivery_vat_percent
     assert_nil @offer_accepted_2.delivery_vat_percent
+    assert_nil @offer_accepted_3.delivery_vat_percent
     assert_nil @offer_automatically_accepted.delivery_vat_percent
     assert_nil @offer_automatically_accepted_2.delivery_vat_percent
     assert_nil @offer_declined.delivery_vat_percent
@@ -344,6 +359,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_nil @delivery_offer_request.delivery_vat_amount
     assert_nil @offer_accepted.delivery_vat_amount
     assert_nil @offer_accepted_2.delivery_vat_amount
+    assert_nil @offer_accepted_3.delivery_vat_amount
     assert_nil @offer_automatically_accepted.delivery_vat_amount
     assert_nil @offer_automatically_accepted_2.delivery_vat_amount
     assert_nil @offer_declined.delivery_vat_amount
@@ -357,6 +373,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 372.0,      @delivery_offer_request.total_price_with_vat
     assert_equal 824.6,      @offer_accepted.total_price_with_vat
     assert_equal 10_664.0,   @offer_accepted_2.total_price_with_vat
+    assert_equal 2000.0,     @offer_accepted_3.total_price_with_vat
     assert_equal 372.0,      @offer_automatically_accepted.total_price_with_vat
     assert_equal 279.0,      @offer_automatically_accepted_2.total_price_with_vat
     assert_equal 62.0,       @offer_declined.total_price_with_vat
@@ -372,6 +389,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal '274472', @delivery_ordered.auction_id
     assert_equal '277075', @offer_accepted.auction_id
     assert_equal '293363', @offer_accepted_2.auction_id
+    assert_equal '298958', @offer_accepted_3.auction_id
     assert_equal '270265', @offer_automatically_accepted.auction_id
     assert_equal '294627', @offer_automatically_accepted_2.auction_id
     assert_equal '277687', @offer_declined.auction_id
@@ -399,6 +417,9 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     title = 'BOBCAT 320 kaivinkone, Lahti'
     assert_equal title, @offer_accepted_2.auction_title
 
+    title = 'Kompressorivaunu Ingersoll Rand 7/31, Lahti'
+    assert_equal title, @offer_accepted_3.auction_title
+
     title = 'Auton keinunostin, 1500 kg, UUSI, Lahti'
     assert_equal title, @offer_automatically_accepted.auction_title
 
@@ -425,6 +446,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal "2016-03-25 19:38".to_time, @delivery_ordered.auction_closing_date
     assert_equal "2016-03-25 20:10".to_time, @offer_accepted.auction_closing_date
     assert_equal "2016-05-01 20:25".to_time, @offer_accepted_2.auction_closing_date
+    assert_equal "2016-05-15 19:52".to_time, @offer_accepted_3.auction_closing_date
     assert_equal "2016-03-25 20:20".to_time, @offer_automatically_accepted.auction_closing_date
     assert_equal "2016-05-15 21:00".to_time, @offer_automatically_accepted_2.auction_closing_date
     assert_equal "2016-03-25 19:40".to_time, @offer_declined.auction_closing_date
@@ -440,6 +462,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 90,   @delivery_ordered.auction_price_without_vat
     assert_equal 665,  @offer_accepted.auction_price_without_vat
     assert_equal 8600, @offer_accepted_2.auction_price_without_vat
+    assert_equal 2000, @offer_accepted_3.auction_price_without_vat
     assert_equal 300,  @offer_automatically_accepted.auction_price_without_vat
     assert_equal 225,  @offer_automatically_accepted_2.auction_price_without_vat
     assert_equal 50,   @offer_declined.auction_price_without_vat
@@ -455,6 +478,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 111.6,     @delivery_ordered.auction_price_with_vat
     assert_equal 824.6,     @offer_accepted.auction_price_with_vat
     assert_equal 10_664.0,  @offer_accepted_2.auction_price_with_vat
+    assert_equal 2000.0,    @offer_accepted_3.auction_price_with_vat
     assert_equal 372.0,     @offer_automatically_accepted.auction_price_with_vat
     assert_equal 279.0,     @offer_automatically_accepted_2.auction_price_with_vat
     assert_equal 62.0,      @offer_declined.auction_price_with_vat
@@ -470,6 +494,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 24, @delivery_ordered.auction_vat_percent
     assert_equal 24, @offer_accepted.auction_vat_percent
     assert_equal 24, @offer_accepted_2.auction_vat_percent
+    assert_equal 0,  @offer_accepted_3.auction_vat_percent
     assert_equal 24, @offer_automatically_accepted.auction_vat_percent
     assert_equal 24, @offer_automatically_accepted_2.auction_vat_percent
     assert_equal 24, @offer_declined.auction_vat_percent
@@ -485,6 +510,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal 21.6,   @delivery_ordered.auction_vat_amount
     assert_equal 159.6,  @offer_accepted.auction_vat_amount
     assert_equal 2064.0, @offer_accepted_2.auction_vat_amount
+    assert_equal 0,      @offer_accepted_3.auction_vat_amount
     assert_equal 72.0,   @offer_automatically_accepted.auction_vat_amount
     assert_equal 54.0,   @offer_automatically_accepted_2.auction_vat_amount
     assert_equal 12.0,   @offer_declined.auction_vat_amount
@@ -499,6 +525,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal customers(:huutokauppa_customer_2), @purchase_price_paid.find_customer
 
     assert_nil @offer_accepted_2.find_customer
+    assert_nil @offer_accepted_3.find_customer
     assert_nil @offer_automatically_accepted_2.find_customer
     assert_nil @purchase_price_paid_2.find_customer
     assert_nil @purchase_price_paid_3.find_customer
@@ -512,6 +539,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     [
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_automatically_accepted,
       @offer_automatically_accepted_2,
       @purchase_price_paid,
@@ -591,6 +619,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     assert_equal sales_order_drafts(:huutokauppa_274472), @delivery_ordered.find_draft
     assert_equal sales_order_drafts(:huutokauppa_277075), @offer_accepted.find_draft
     assert_equal sales_order_drafts(:huutokauppa_293363), @offer_accepted_2.find_draft
+    assert_equal sales_order_drafts(:huutokauppa_298958), @offer_accepted_3.find_draft
     assert_equal sales_order_drafts(:huutokauppa_270265), @offer_automatically_accepted.find_draft
     assert_equal sales_order_drafts(:huutokauppa_294627), @offer_automatically_accepted_2.find_draft
     assert_equal sales_order_drafts(:huutokauppa_277687), @offer_declined.find_draft
@@ -609,6 +638,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
     [
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_automatically_accepted,
       @offer_automatically_accepted_2,
       @purchase_price_paid,
@@ -692,6 +722,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_ordered,
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_automatically_accepted,
       @offer_automatically_accepted_2,
       @offer_declined,
@@ -704,9 +735,9 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       row = email.find_draft.rows.first
       qty = row.tilkpl
 
-      assert_equal email.auction_price_without_vat / qty, row.hinta
-      assert_equal email.auction_price_without_vat / qty, row.hinta_alkuperainen
-      assert_equal email.auction_price_without_vat / qty, row.hinta_valuutassa
+      assert_equal (email.auction_price_without_vat / qty).round(2), row.hinta.round(2)
+      assert_equal (email.auction_price_without_vat / qty).round(2), row.hinta_alkuperainen.round(2)
+      assert_equal (email.auction_price_without_vat / qty).round(2), row.hinta_valuutassa.round(2)
       assert_equal email.auction_price_without_vat,       row.rivihinta
       assert_equal email.auction_price_without_vat,       row.rivihinta_valuutassa
       assert_equal email.auction_title,                   row.nimitys
@@ -738,6 +769,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       [
         @offer_accepted,
         @offer_accepted_2,
+        @offer_accepted_3,
         @offer_automatically_accepted,
         @offer_automatically_accepted_2,
         @purchase_price_paid,
@@ -787,6 +819,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_offer_request,
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_automatically_accepted,
       @offer_automatically_accepted_2,
       @offer_declined,
@@ -809,6 +842,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_ordered,
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_automatically_accepted,
       @offer_automatically_accepted_2,
       @offer_declined,
@@ -832,6 +866,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_ordered,
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_declined,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
@@ -856,6 +891,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @delivery_ordered,
       @offer_accepted,
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_declined,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
@@ -901,6 +937,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
     [
       @offer_accepted_2,
+      @offer_accepted_3,
       @offer_automatically_accepted_2,
       @purchase_price_paid_2,
       @purchase_price_paid_3,
@@ -918,6 +955,7 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
   test '#name' do
     assert_equal 'Testi Testit Testitestit', @offer_accepted.name
     assert_equal 'Testites Oy',              @offer_accepted_2.name
+    assert_equal 'Testit ky T',              @offer_accepted_3.name
     assert_equal 'Test-testi Testite',       @offer_automatically_accepted.name
     assert_equal 'TE-Testitest Oy',          @offer_automatically_accepted_2.name
     assert_equal 'Test-testi Testite',       @purchase_price_paid.name

--- a/test/fixtures/delivery_methods.yml
+++ b/test/fixtures/delivery_methods.yml
@@ -24,11 +24,10 @@ kiitolinja:
   tulostustapa: H
   <<: *DEFAULTS
 
-itella_economy_16:
-  selite: Itella Economy 16
+posti_economy_16:
+  selite: Posti Economy 16
   tulostustapa: H
   rahtikirja: rahtikirja_unifaun_uo_siirto.inc
-  rahdinkuljettaja: IT16
   <<: *DEFAULTS
 
 nouto:

--- a/test/fixtures/head_details.yml
+++ b/test/fixtures/head_details.yml
@@ -14,7 +14,7 @@ two:
   head: pi_H
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627, 298958].each do |auction_id| %>
 huutokauppa_<%= auction_id %>_detail:
   head: huutokauppa_<%= auction_id %>
   laskutus_nimi: Testi Testaaja

--- a/test/fixtures/head_details.yml
+++ b/test/fixtures/head_details.yml
@@ -14,7 +14,7 @@ two:
   head: pi_H
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627].each do |auction_id| %>
 huutokauppa_<%= auction_id %>_detail:
   head: huutokauppa_<%= auction_id %>
   laskutus_nimi: Testi Testaaja

--- a/test/fixtures/sales_order/drafts.yml
+++ b/test/fixtures/sales_order/drafts.yml
@@ -28,7 +28,7 @@ not_finished_order:
   terms_of_payment: hundred_days_net
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627].each do |auction_id| %>
 huutokauppa_<%= auction_id %>:
   toim_nimi: Testi Testaaja
   toim_nimitark: Testi Testaaja

--- a/test/fixtures/sales_order/drafts.yml
+++ b/test/fixtures/sales_order/drafts.yml
@@ -28,7 +28,7 @@ not_finished_order:
   terms_of_payment: hundred_days_net
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627, 298958].each do |auction_id| %>
 huutokauppa_<%= auction_id %>:
   toim_nimi: Testi Testaaja
   toim_nimitark: Testi Testaaja

--- a/test/fixtures/sales_order/rows.yml
+++ b/test/fixtures/sales_order/rows.yml
@@ -28,3 +28,10 @@ huutokauppa_294627_row_1:
   tilkpl: 3
   tyyppi: L
   <<: *DEFAULTS
+
+huutokauppa_298958_row_1:
+  order: huutokauppa_298958
+  tuoteno: hammer123
+  tilkpl: 7
+  tyyppi: L
+  <<: *DEFAULTS

--- a/test/fixtures/sales_order/rows.yml
+++ b/test/fixtures/sales_order/rows.yml
@@ -13,10 +13,18 @@ so_row_one:
   tyyppi: L
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363].each do |auction_id| %>
 huutokauppa_<%= auction_id %>_row_1:
   order: huutokauppa_<%= auction_id %>
   tuoteno: hammer123
+  tilkpl: 1
   tyyppi: L
   <<: *DEFAULTS
 <% end %>
+
+huutokauppa_294627_row_1:
+  order: huutokauppa_294627
+  tuoteno: hammer123
+  tilkpl: 3
+  tyyppi: L
+  <<: *DEFAULTS

--- a/test/fixtures/sales_order/rows.yml
+++ b/test/fixtures/sales_order/rows.yml
@@ -13,7 +13,7 @@ so_row_one:
   tyyppi: L
   <<: *DEFAULTS
 
-<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363].each do |auction_id| %>
+<% [270265, 274472, 277075, 277687, 279590, 285888, 285703, 287912, 293363, 294627].each do |auction_id| %>
 huutokauppa_<%= auction_id %>_row_1:
   order: huutokauppa_<%= auction_id %>
   tuoteno: hammer123

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -146,8 +146,8 @@ class HuutokauppaJobTest < ActiveJob::TestCase
 
     order = SalesOrder::Order.find_by!(viesti: 274_472)
 
-    assert_equal 'Test-testi testit Testites',         order.toim_nimi
-    assert_equal delivery_methods(:itella_economy_16), order.delivery_method
+    assert_equal 'Test-testi testit Testites',        order.toim_nimi
+    assert_equal delivery_methods(:posti_economy_16), order.delivery_method
 
     assert_equal 'ok', incoming_mail.reload.status
     message = "Päivitettiin tilauksen (Tilausnumero: #{order.id}, Huutokauppa: #{order.viesti}) toimitustiedot."


### PR DESCRIPTION
* Add new test email of type offer automatically accepted
* Add new test email of type offer accepted
* Update company name to order instead of customer name when present
* Set customer name to company name when present when creating or updating customers
* Rename delivery type Itella Economy 16 to Posti Economy 16
* Set customer piiri to Huutokauppa when creating or updating customer
* Take tilkpl into account when updating product prices to order
* Add correct laji for customer depending whether they are companies or not