### PR TITLE
Huutokauppa: Fix to delivery info update

### DIFF
--- a/app/classes/huutokauppa_mail.rb
+++ b/app/classes/huutokauppa_mail.rb
@@ -284,13 +284,9 @@ class HuutokauppaMail
   end
 
   def update_order_delivery_info
-    return unless delivery_name
+    return unless delivery_name && find_draft
 
-    order = find_order || find_draft
-
-    return unless order
-
-    order.update!(
+    find_draft.update!(
       toim_email: delivery_email,
       toim_nimi: delivery_name,
       toim_osoite: delivery_address,
@@ -299,7 +295,7 @@ class HuutokauppaMail
       toim_puh: delivery_phone,
     )
 
-    @messages << "Päivitettiin tilauksen #{order_message_info(order)} toimitustiedot."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} toimitustiedot."
 
     true
   end
@@ -371,13 +367,11 @@ class HuutokauppaMail
   end
 
   def update_delivery_method_to_itella_economy_16
-    order = find_order || find_draft
+    return unless find_draft
 
-    return unless order
+    find_draft.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Posti Economy 16'))
 
-    order.update!(delivery_method: DeliveryMethod.find_by!(selite: 'Posti Economy 16'))
-
-    @messages << "Päivitettiin tilauksen #{order_message_info(order)} toimitustavaksi Posti Economy 16."
+    @messages << "Päivitettiin tilauksen #{order_message_info(find_draft)} toimitustavaksi Posti Economy 16."
 
     true
   end

--- a/test/classes/huutokauppa_mail_test.rb
+++ b/test/classes/huutokauppa_mail_test.rb
@@ -690,20 +690,16 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
 
   test '#update_order_delivery_info' do
     [@delivery_offer_request, @delivery_ordered].each do |email|
-      draft = email.find_draft
-      draft.tila = 'L'
-      draft.save(validate: false)
-
       assert email.update_order_delivery_info
 
-      assert_equal email.delivery_address,  email.find_order.toim_osoite
-      assert_equal email.delivery_city,     email.find_order.toim_postitp
-      assert_equal email.delivery_email,    email.find_order.toim_email
-      assert_equal email.delivery_name,     email.find_order.toim_nimi
-      assert_equal email.delivery_phone,    email.find_order.toim_puh
-      assert_equal email.delivery_postcode, email.find_order.toim_postino
+      assert_equal email.delivery_address,  email.find_draft.toim_osoite
+      assert_equal email.delivery_city,     email.find_draft.toim_postitp
+      assert_equal email.delivery_email,    email.find_draft.toim_email
+      assert_equal email.delivery_name,     email.find_draft.toim_nimi
+      assert_equal email.delivery_phone,    email.find_draft.toim_puh
+      assert_equal email.delivery_postcode, email.find_draft.toim_postino
 
-      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_order.id}, Huutokauppa: #{email.auction_id}) toimitustiedot."
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) toimitustiedot."
       assert_includes email.messages, message
     end
 
@@ -871,14 +867,10 @@ class HuutokauppaMailTest < ActiveSupport::TestCase
       @purchase_price_paid_2,
       @purchase_price_paid_3,
     ].each do |email|
-      draft = email.find_draft
-      draft.tila = 'L'
-      draft.save(validate: false)
-
       email.update_delivery_method_to_itella_economy_16
 
-      assert_equal delivery_methods(:posti_economy_16), email.find_order.delivery_method
-      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_order.id}, Huutokauppa: #{email.auction_id}) toimitustavaksi Posti Economy 16."
+      assert_equal delivery_methods(:posti_economy_16), email.find_draft.delivery_method
+      message = "Päivitettiin tilauksen (Tilausnumero: #{email.find_draft.id}, Huutokauppa: #{email.auction_id}) toimitustavaksi Posti Economy 16."
       assert_includes email.messages, message
     end
   end

--- a/test/jobs/huutokauppa_job_test.rb
+++ b/test/jobs/huutokauppa_job_test.rb
@@ -135,16 +135,12 @@ class HuutokauppaJobTest < ActiveJob::TestCase
   test 'order delivery info is updated and delivery method set when type is delivery ordered' do
     incoming_mail = incoming_mails(:three)
 
-    draft = sales_order_drafts(:huutokauppa_274472)
-    draft.tila = 'L'
-    draft.save(validate: false)
-
     incoming_mail.raw_source = huutokauppa_email(:delivery_ordered_1)
     incoming_mail.save!
 
     HuutokauppaJob.perform_now(id: incoming_mail.id)
 
-    order = SalesOrder::Order.find_by!(viesti: 274_472)
+    order = SalesOrder::Draft.find_by!(viesti: 274_472)
 
     assert_equal 'Test-testi testit Testites',        order.toim_nimi
     assert_equal delivery_methods(:posti_economy_16), order.delivery_method


### PR DESCRIPTION
Update delivery info for draft instead of order because when marking the order as done with preliminary invoice, the order stays as draft.