### PR TITLE
Date and DateTime defaults

### DIFF
--- a/app/models/base_model.rb
+++ b/app/models/base_model.rb
@@ -11,8 +11,8 @@ class BaseModel < ActiveRecord::Base
         include UserDefinedValidations
         include DateDatetimeDefaults
 
-        before_create :set_date_fields
-        after_create :fix_datetime_fields
+        before_save :set_date_fields
+        after_save :fix_datetime_fields
       end
     end
   end

--- a/app/models/concerns/date_datetime_defaults.rb
+++ b/app/models/concerns/date_datetime_defaults.rb
@@ -3,7 +3,7 @@ module DateDatetimeDefaults
 
   def set_date_fields
     self.class.columns.each do |column|
-      next if !column.type.in?([:date, :datetime]) || send(column.name) || column.null
+      next if !column.type.in?([:date, :datetime]) || send(column.name).present? || column.null
 
       case column.type
       # Date fields can be set to zero

--- a/app/models/concerns/date_datetime_defaults.rb
+++ b/app/models/concerns/date_datetime_defaults.rb
@@ -4,6 +4,7 @@ module DateDatetimeDefaults
   def set_date_fields
     self.class.columns.each do |column|
       next if !column.type.in?([:date, :datetime]) || send(column.name).present? || column.null
+      next if column.name.in?(['muutospvm', 'luontiaika', 'created_at', 'updated_at'])
 
       case column.type
       # Date fields can be set to zero

--- a/app/models/head.rb
+++ b/app/models/head.rb
@@ -22,9 +22,6 @@ class Head < BaseModel
   scope :paid, -> { where.not(mapvm: 0) }
   scope :unpaid, -> { where(mapvm: 0) }
 
-  before_create :set_date_fields
-  after_create :fix_datetime_fields
-
   def self.default_child_instance
     child_class 'N'
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -43,7 +43,6 @@ class Product < BaseModel
   self.primary_key = :tunnus
 
   before_save :defaults
-  before_create :set_date_fields
 
   enum tuotetyyppi: {
     expence: 'B',
@@ -125,15 +124,6 @@ class Product < BaseModel
   end
 
   private
-
-    def set_date_fields
-      # Date fields can be set to zero
-      self.vihapvm           ||= 0
-      self.epakurantti25pvm  ||= 0
-      self.epakurantti50pvm  ||= 0
-      self.epakurantti75pvm  ||= 0
-      self.epakurantti100pvm ||= 0
-    end
 
     def defaults
       self.vienti ||= ''

--- a/app/models/product/supplier.rb
+++ b/app/models/product/supplier.rb
@@ -4,13 +4,4 @@ class Product::Supplier < BaseModel
 
   self.table_name = :tuotteen_toimittajat
   self.primary_key = :tunnus
-
-  before_create :set_date_fields
-
-  private
-
-    def set_date_fields
-      # Date fields can be set to zero
-      self.tehdas_saldo_paivitetty ||= 0
-    end
 end

--- a/app/models/row.rb
+++ b/app/models/row.rb
@@ -6,9 +6,6 @@ class Row < BaseModel
 
   validates :product, presence: true
 
-  before_create :set_defaults
-  after_create :fix_datetime_fields
-
   self.table_name = :tilausrivi
   self.primary_key = :tunnus
   self.inheritance_column = :tyyppi
@@ -40,33 +37,4 @@ class Row < BaseModel
   def self.picked
     where.not(keratty: '')
   end
-
-  private
-
-    def set_defaults
-      # Date fields can be set to zero
-      self.toimaika  ||= 0
-      self.kerayspvm ||= 0
-
-      # Datetime fields don't accept zero, so let's set them to epoch zero (temporarily)
-      self.laadittu       ||= Time.at(0)
-      self.kerattyaika    ||= Time.at(0)
-      self.toimitettuaika ||= Time.at(0)
-      self.laskutettuaika ||= Time.at(0)
-    end
-
-    def fix_datetime_fields
-      params  = {}
-      zero    = '0000-00-00 00:00:00'
-      epoch   = Time.at(0)
-
-      # Change all datetime fields to zero if they are epoch
-      params[:laadittu]       = zero if laadittu       == epoch
-      params[:kerattyaika]    = zero if kerattyaika    == epoch
-      params[:toimitettuaika] = zero if toimitettuaika == epoch
-      params[:laskutettuaika] = zero if laskutettuaika == epoch
-
-      # update_columns skips all validations and updates values directly with sql
-      update_columns params if params.present?
-    end
 end

--- a/test/modules/date_datetime_defaults_test.rb
+++ b/test/modules/date_datetime_defaults_test.rb
@@ -1,36 +1,115 @@
 require 'test_helper'
 
 class DateDatetimeDefaultsTest < ActiveSupport::TestCase
-  fixtures %w(
-    heads
-    supplier_product_informations
-    terms_of_payments
-  )
+  setup do
+    @valid_datetime   = '2012-10-20 05:40:50'
+    @zero_datetime    = '0000-00-00 00:00:00'
 
-  test 'date fields are set to zero by default correctly' do
-    head = Head.create!(tila: 'N')
+    @valid_date   = '2012-10-20'
+    @zero_date    = '0000-00-00'
 
-    assert_equal 0,                    head.erpcm
-    assert_equal '2016-01-02'.to_date, heads(:si_one).erpcm
+    Current.user = users :bob
   end
 
-  test 'datetime fields are set to zero by default correctly' do
-    head = Head.create!(tila: 'N')
+  test 'date fields are set to zero on create' do
+    # create with valid time
+    head = SalesOrder::Order.create! erpcm: @valid_date
+    assert_equal @valid_date, head.erpcm_before_type_cast
 
-    assert_equal '0000-00-00 00:00:00',                  head.h1time
-    assert_equal Time.zone.local(2016, 1, 2, 12, 0, 12), heads(:si_one).h1time
+    # create with zero time.
+    # even without typecast, rails gives value 0, but it's *really* '0000-00-00' in the db
+    head = SalesOrder::Order.create! erpcm: @zero_date
+    assert_equal 0, head.erpcm_before_type_cast
+
+    # create without time
+    # even without typecast, rails gives value 0, but it's *really* '0000-00-00' in the db
+    head = SalesOrder::Order.create! erpcm: nil
+    assert_equal 0, head.erpcm_before_type_cast
   end
 
-  test 'date fields with default values are not set to zero' do
-    terms_of_payment = TermsOfPayment.create!(teksti: 'Testimaksuehto')
+  test 'date fields are set to zero on update' do
+    # update with valid time
+    head = SalesOrder::Order.create! erpcm: nil
+    head.update! erpcm: @valid_date
+    assert_equal @valid_date, head.erpcm_before_type_cast
 
-    assert_nil terms_of_payment.kassa_abspvm
+    # update with zero time
+    # even without typecast, rails gives value 0, but it's *really* '0000-00-00' in the db
+    head = SalesOrder::Order.create! erpcm: @valid_date
+    head.update! erpcm: @zero_date
+    assert_equal 0, head.erpcm_before_type_cast
+
+    # update without time
+    head = SalesOrder::Order.create! erpcm: @valid_date
+    head.update! erpcm: nil
+    # even without typecast, rails gives value 0, but it's *really* '0000-00-00' in the db
+    assert_equal 0, head.erpcm_before_type_cast
+  end
+
+  test 'datetime fields are set to zero on create' do
+    # create with valid time
+    head = SalesOrder::Order.create! h1time: @valid_datetime
+    assert_equal @valid_datetime, head.h1time_before_type_cast
+
+    # create with zero time
+    head = SalesOrder::Order.create! h1time: @zero_datetime
+    assert_equal @zero_datetime, head.h1time_before_type_cast
+
+    # create without time
+    head = SalesOrder::Order.create! h1time: nil
+    assert_equal @zero_datetime, head.h1time_before_type_cast
+  end
+
+  test 'datetime fields are set to zero on update' do
+    # update with valid time
+    head = SalesOrder::Order.create! h1time: nil
+    head.update! h1time: @valid_datetime
+    assert_equal @valid_datetime, head.h1time_before_type_cast
+
+    # update with zero time
+    head = SalesOrder::Order.create! h1time: @valid_datetime
+    head.update! h1time: @zero_datetime
+    assert_equal @zero_datetime, head.h1time_before_type_cast
+
+    # update without time
+    head = SalesOrder::Order.create! h1time: @valid_datetime
+    head.update! h1time: nil
+    assert_equal @zero_datetime, head.h1time_before_type_cast
+  end
+
+  test 'date fields with default null are not set to zero on create' do
+    terms_of_payment = TermsOfPayment.create! teksti: 'Testimaksuehto', abs_pvm: nil
+    assert_nil terms_of_payment.abs_pvm
+
+    terms_of_payment = TermsOfPayment.create! teksti: 'Testimaksuehto', abs_pvm: @valid_date
+    assert_equal @valid_date, terms_of_payment.read_attribute_before_type_cast(:abs_pvm)
+  end
+
+  test 'date fields with default null are not set to zero on update' do
+    terms_of_payment = TermsOfPayment.create! teksti: 'Testimaksuehto', abs_pvm: nil
+    terms_of_payment.update! abs_pvm: @valid_date
+    assert_equal @valid_date, terms_of_payment.read_attribute_before_type_cast(:abs_pvm)
+
+    terms_of_payment = TermsOfPayment.create! teksti: 'Testimaksuehto', abs_pvm: @valid_date
+    terms_of_payment.update! abs_pvm: nil
     assert_nil terms_of_payment.abs_pvm
   end
 
-  test 'datetime fields with default values are not set to zero' do
-    supplier_product_information = SupplierProductInformation.create!(product_id: '123')
+  test 'datetime fields with default null are not set to zero on create' do
+    spi = SupplierProductInformation.create! product_id: '123', p_added_date: nil
+    assert_nil spi.p_added_date
 
-    assert_nil supplier_product_information.p_added_date
+    spi = SupplierProductInformation.create! product_id: '123', p_added_date: @valid_datetime
+    assert_equal @valid_datetime, spi.read_attribute_before_type_cast(:p_added_date)
+  end
+
+  test 'datetime fields with default null are not set to zero on update' do
+    spi = SupplierProductInformation.create! product_id: '123', p_added_date: nil
+    spi.update! p_added_date: @valid_datetime
+    assert_equal @valid_datetime, spi.read_attribute_before_type_cast(:p_added_date)
+
+    spi = SupplierProductInformation.create! product_id: '123', p_added_date: @valid_datetime
+    spi.update! p_added_date: nil
+    assert_nil spi.p_added_date
   end
 end

--- a/test/modules/date_datetime_defaults_test.rb
+++ b/test/modules/date_datetime_defaults_test.rb
@@ -112,4 +112,15 @@ class DateDatetimeDefaultsTest < ActiveSupport::TestCase
     spi.update! p_added_date: nil
     assert_nil spi.p_added_date
   end
+
+  test 'datetime defaults do not overried created_at/updated_at' do
+    spi = SupplierProductInformation.create! product_id: '123'
+    assert_nil spi.p_added_date
+    assert_not_nil spi.created_at
+    assert_not_nil spi.updated_at
+
+    status = Product::Status.create! selite: 'foo'
+    assert_not_equal @zero_datetime, status.luontiaika_before_type_cast
+    assert_not_equal @zero_datetime, status.muutospvm_before_type_cast
+  end
 end


### PR DESCRIPTION
* handle zero dates on update
* don't override created/updated timestamps
* don't override logic in child models