### PR TITLE
Company copier fix

### DIFF
--- a/app/classes/company_copier.rb
+++ b/app/classes/company_copier.rb
@@ -70,7 +70,7 @@ class CompanyCopier
 
         copy = record.dup
         copy.assign_attributes attributes.merge(default_attributes)
-        copy.save!
+        copy.save(validate: false)
         copy
       end
     end

--- a/test/classes/company_copier_test.rb
+++ b/test/classes/company_copier_test.rb
@@ -77,7 +77,7 @@ class CompanyCopierTest < ActiveSupport::TestCase
   end
 
   test '#copy destroys all copied data if anything goes wrong' do
-    Account.any_instance.stubs(:save!).raises(StandardError)
+    Account.any_instance.stubs(:save).raises(StandardError)
 
     assert_no_difference [
       'Account.unscoped.count',


### PR DESCRIPTION
Don’t validate data to be duplicated, because it should already be valid and it sometimes breaks the duplication process when rows are not saved in proper order.