### PR TITLE
Company copier email fix

### DIFF
--- a/app/classes/company_copier.rb
+++ b/app/classes/company_copier.rb
@@ -150,7 +150,7 @@ class CompanyCopier
         customer = Customer.create!(
           nimi: new_company.nimi,
           ytunnus: new_company.ytunnus,
-          email: user_attributes.map { |h| h[:kuka] }.join(', '),
+          email: user_attributes.first[:kuka],
           kauppatapahtuman_luonne: 0,
           alv: Keyword::Vat.first.selite,
         )

--- a/test/classes/company_copier_test.rb
+++ b/test/classes/company_copier_test.rb
@@ -233,7 +233,7 @@ class CompanyCopierTest < ActiveSupport::TestCase
     Current.company = estonian
     customer = estonian.customers.find_by(nimi: 'Kala Oy Esimerkki')
     assert_not_nil customer
-    assert_equal 'extranet-user@example.com, second-user@example.com', customer.email
+    assert_equal 'extranet-user@example.com', customer.email
 
     user = estonian.users.find_by(kuka: 'extranet-user@example.com')
     assert_not_nil user


### PR DESCRIPTION
Only copy one email to customer, because otherwise the length would be too long