### PR TITLE
query_string_auth päälle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ log/localeapp.yml
 
 # Ignore byebug history file
 /.byebug_history
+
+.env_org

--- a/app/classes/woo/base.rb
+++ b/app/classes/woo/base.rb
@@ -12,6 +12,7 @@ class Woo::Base
       consumer_secret,
       wp_api: true,
       version: 'wc/v1',
+      query_string_auth: true
     )
   end
 


### PR DESCRIPTION
Force Basic Authentication as query string when using under HTTPS